### PR TITLE
Simplified http dsl call with KoHttp. 

### DIFF
--- a/talaiot/build.gradle.kts
+++ b/talaiot/build.gradle.kts
@@ -24,7 +24,7 @@ gradlePlugin {
         }
         dependencies {
             
-            api("io.github.rybalkinsd:kohttp:0.7.1")
+            api("io.github.rybalkinsd:kohttp:0.8.0")
             api("guru.nidi:graphviz-java:0.8.3")
             testImplementation("io.kotlintest:kotlintest-runner-junit5:3.1.11")
             testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.0.0-RC1")

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/request/SimpleRequest.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/request/SimpleRequest.kt
@@ -2,9 +2,7 @@ package com.cdsap.talaiot.request
 
 import com.cdsap.talaiot.logger.LogTracker
 import io.github.rybalkinsd.kohttp.dsl.httpPost
-import okhttp3.RequestBody
-import okhttp3.Response
-import java.lang.Exception
+import io.github.rybalkinsd.kohttp.ext.url
 import java.net.URL
 
 
@@ -14,29 +12,23 @@ class SimpleRequest(mode: LogTracker) : Request {
     override fun send(url: String, content: String) {
         val urlSpec = URL(url)
         logTracker.log(url)
-        var response: Response? = null
         try {
             val query = urlSpec.query.split("=")
-            response = httpPost {
-                host = urlSpec.host
-                if (urlSpec.port != -1) {
-                    port = urlSpec.port
-                }
-                scheme = urlSpec.protocol
-                path = urlSpec.path
+            httpPost {
+                url(urlSpec)
+
                 param {
                     query[0] to query[1]
                 }
-                body {
-                    RequestBody.create(null, content)
-                }
-            }
-            logTracker.log(response.message())
 
+                body {
+                    string(content)
+                }
+            }.also {
+                logTracker.log(it.message())
+            }
         } catch (e: Exception) {
             logTracker.log(e.message ?: "error requesting $url")
-        } finally {
-            response?.body()?.close()
         }
     }
 }


### PR DESCRIPTION
- Simplified http dsl call with KoHttp 
- KoHttp version upd 0.7.1 -> 0.8.0 (allows `url()` and `body { string(content) }` )
- finally blocked removed b/c source code never reads response body 