### PR TITLE
Report gradleSync instead of many generateDebugSources tasks as a requestedTask(Workaround for #79)

### DIFF
--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/metrics/GradleMetrics.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/metrics/GradleMetrics.kt
@@ -109,7 +109,12 @@ class GradleBuildCachePushEnabled : GradleMetric<String?>(
 
 class GradleRequestedTasksMetric : GradleMetric<String>(
     provider = {
-        it.gradle.startParameter.taskNames.joinToString(separator = " ")
+        val taskNames = it.gradle.startParameter.taskNames
+        if (taskNames.all { it.endsWith("generateDebugSources") }) {
+            "gradleSync"
+        } else {
+            taskNames.joinToString(separator = " ")
+        }
     },
-    assigner = { report, value -> report.requestedTasks = value}
+    assigner = { report, value -> report.requestedTasks = value }
 )


### PR DESCRIPTION
#79 