### PR TITLE
fix missing task metrics

### DIFF
--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/MetricsConfiguration.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/MetricsConfiguration.kt
@@ -152,6 +152,7 @@ class MetricsConfiguration {
         }
 
         addCustomBuildMetrics()
+        addCustomTaskMetrics()
 
         return metrics
     }


### PR DESCRIPTION
custom properties are missing from task metrics because call to `addCustomTaskMetrics()` is missing.