### PR TITLE
Support Gradle task abbreviation

### DIFF
--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/util/TaskAbbreviationMatcher.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/util/TaskAbbreviationMatcher.kt
@@ -1,0 +1,38 @@
+package com.cdsap.talaiot.util
+
+import org.gradle.util.NameMatcher
+
+/**
+ * Match task abbreviation to a full task name using list of executed tasks.
+ * Fallback to the abbreviation if couldn't find a corresponding full name.
+ */
+class TaskAbbreviationMatcher(private val executedTasks: List<TaskName>) {
+    private val nameMatcher = NameMatcher()
+
+    fun findRequestedTask(taskName: String): String {
+        val lastIndex = taskName.lastIndexOf(':')
+        return if (lastIndex == -1) {
+            val foundTask: String? = nameMatcher.find(
+                taskName,
+                executedTasks.filter { !it.path.contains(':') }.map { it.name to it.path }.toMap()
+            )
+            foundTask ?: taskName
+        } else {
+            val pathWithoutTaskName = taskName.substring(0, lastIndex + 1).let {
+                if (it[0] != ':') {
+                    ":$it"
+                } else {
+                    it
+                }
+            }
+            val taskNameWithoutPath = taskName.substring(lastIndex + 1)
+            val foundTask: String? = nameMatcher.find(
+                taskNameWithoutPath,
+                executedTasks.filter { it.path.startsWith(pathWithoutTaskName) }
+                    .map { it.name to it.path }
+                    .toMap()
+            )
+            foundTask ?: taskName
+        }
+    }
+}

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/util/TaskName.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/util/TaskName.kt
@@ -1,0 +1,6 @@
+package com.cdsap.talaiot.util
+
+/**
+ * Example: TaskName(name = "assembleDebug", path = ":app:assembleDebug")
+ */
+data class TaskName(val name: String, val path: String)

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/util/TaskAbbreviationMatcherTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/util/TaskAbbreviationMatcherTest.kt
@@ -1,0 +1,55 @@
+package com.cdsap.talaiot.util
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.BehaviorSpec
+
+class TaskAbbreviationMatcherTest : BehaviorSpec({
+    given("a TaskAbbreviationMatcher") {
+        val executedTasks = listOf(
+            TaskName("assembleDebug", ":app:assembleDebug"),
+            TaskName("compileKotlin", ":app:compileKotlin"),
+            TaskName("assembleDebug", ":moduleA:assembleDebug"),
+            TaskName("compileKotlin", ":moduleA:compileKotlin"),
+            TaskName("assembleDebug", ":modules:moduleB:assembleDebug"),
+            TaskName("compileKotlin", ":modules:moduleB:compileKotlin"),
+            TaskName("assembleDebug", "assembleDebug")
+        )
+        println("map: $executedTasks")
+        val taskAbbreviationMatcher = TaskAbbreviationMatcher(executedTasks)
+
+        `when`("search abbreviation for single task") {
+            then("return full task name") {
+                val fullTaskName = taskAbbreviationMatcher.findRequestedTask(":app:assDeb")
+                fullTaskName.shouldBe(":app:assembleDebug")
+            }
+        }
+
+        `when`("search abbreviation for single task without leading semicolon") {
+            then("return full task name") {
+                val fullTaskName = taskAbbreviationMatcher.findRequestedTask("app:assDeb")
+                fullTaskName.shouldBe(":app:assembleDebug")
+            }
+        }
+
+        `when`("search abbreviation for top task") {
+            then("return abbreviation") {
+                val fullTaskName = taskAbbreviationMatcher.findRequestedTask("aD")
+                fullTaskName.shouldBe("assembleDebug")
+            }
+        }
+
+        `when`("search abbreviation for a submovule task") {
+            then("return abbreviation") {
+                val fullTaskName = taskAbbreviationMatcher.findRequestedTask(":modules:moduleB:aD")
+                fullTaskName.shouldBe(":modules:moduleB:assembleDebug")
+            }
+        }
+
+        `when`("search abbreviation for non existent task") {
+            then("return abbreviation") {
+                val fullTaskName = taskAbbreviationMatcher.findRequestedTask("moduleB:assDeb")
+                fullTaskName.shouldBe("moduleB:assDeb")
+            }
+        }
+    }
+})


### PR DESCRIPTION
Always use a full task name. This covers the cases when the Gradle task is executed by an abbreviation (https://docs.gradle.org/current/userguide/command_line_interface.html#task_name_abbreviation).
It fixes the following issues:
* "build.requestedTask" reported differently if an abbreviation was used. Now it's always a full name.
* "task.rootNode is false", if the task was executed using abbreviation. This is because we were comparing the full name and abbreviation to set "rootNode" flag.

Fixes: https://github.com/cdsap/Talaiot/issues/132

Implementation details:
* I did research, but couldn't find a better way to transform task abbreviation than use "NameMatcher". See: https://discuss.gradle.org/t/how-to-disable-gradle-task-name-abbreviation/7145/4
* In the beginning, I was hesitant about using "addTaskExecutionGraphListener" since it delays the queue population. Now I think it's fine since the task graph should be ready before the execution of the tasks. I also didn't notice any problems in my tests.
* I didn't cover "TalaiotListener" and "GradleRequestedTasksMetric" with tests. From one side there are no existing tests. From the other side, I could go for a heavy mocking or for a fully functional test (https://guides.gradle.org/testing-gradle-plugins/#functional-tests). Both approaches have disadvantages and I don't know which approach plugin authors prefer.