### PR TITLE
adding extra thread for heavy operations(graphtask)

### DIFF
--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -8,8 +8,12 @@ repositories {
 }
 
 plugins {
-    kotlin("jvm") version "1.3.11"
+    kotlin("jvm") version "1.3.60"
     id("talaiot") version "1.0.10-SNAPSHOT"
+}
+
+dependencies{
+    implementation ("org.jetbrains.kotlin:kotlin-stdlib:1.3.60")
 }
 
 talaiot {

--- a/talaiot/build.gradle.kts
+++ b/talaiot/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     `maven-publish`
     groovy
     id("jacoco")
-    kotlin("jvm") version "1.3.11"
+    kotlin("jvm") version "1.3.60"
     id("com.gradle.plugin-publish") version "0.10.0"
     id("com.novoda.bintray-release")
 }

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/provider/PublishersProvider.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/provider/PublishersProvider.kt
@@ -9,6 +9,7 @@ import com.cdsap.talaiot.publisher.pushgateway.PushGatewayPublisher
 import com.cdsap.talaiot.publisher.timeline.TimelinePublisher
 import com.cdsap.talaiot.request.SimpleRequest
 import org.gradle.api.Project
+import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 
 /**
@@ -19,8 +20,9 @@ class PublishersProvider(
      * Gradle Project used to retrieve the extension
      */
     val project: Project,
-    val logger: LogTracker
-
+    val logger: LogTracker,
+    val executor: Executor,
+    val heavyExecutor: Executor
 ) : Provider<List<Publisher>> {
 
     /**
@@ -32,7 +34,6 @@ class PublishersProvider(
     override fun get(): List<Publisher> {
         val publishers = mutableListOf<Publisher>()
         val talaiotExtension = project.extensions.getByName("talaiot") as TalaiotExtension
-        val executor = Executors.newSingleThreadExecutor()
 
         talaiotExtension.publishers?.apply {
 
@@ -55,7 +56,7 @@ class PublishersProvider(
                     TaskDependencyGraphPublisher(
                         this,
                         logger,
-                        executor,
+                        heavyExecutor,
                         GraphPublisherFactoryImpl()
                     )
                 )

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/publisher/InfluxDbPublisher.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/publisher/InfluxDbPublisher.kt
@@ -13,7 +13,7 @@ import org.influxdb.dto.Point
 import java.util.concurrent.Executor
 import java.util.concurrent.TimeUnit
 
-const val TIMEOUT_SEC = 60L
+const val TIMEOUT_SEC = 10L
 
 /**
  * Publisher using InfluxDb and LineProtocol format to send the metrics

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/publisher/TaskDependencyGraphPublisher.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/publisher/TaskDependencyGraphPublisher.kt
@@ -33,7 +33,7 @@ open class TaskDependencyGraphPublisher(
     private val graphPublisherFactory: GraphPublisherFactory
 ) : Publisher {
 
-    private val TAG = "OutputPublisher"
+    private val TAG = "TaskDependencyGraphPublisher"
 
     override fun publish(report: ExecutionReport) {
         logTracker.log(TAG, "================")

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/publisher/PublishersProviderTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/publisher/PublishersProviderTest.kt
@@ -17,7 +17,7 @@ class PublishersProviderTest : BehaviorSpec({
         `when`("No configuration is included") {
             val project = ProjectBuilder.builder().build()
             project.extensions.create("talaiot", TalaiotExtension::class.java, project)
-            val publishersProvider = PublishersProvider(project, logger)
+            val publishersProvider = PublishersProvider(project, logger, TestExecutor(), TestExecutor())
             then("no publishers are  ") {
                 assert(publishersProvider.get().isEmpty())
             }
@@ -32,7 +32,7 @@ class PublishersProviderTest : BehaviorSpec({
                     dbName = ""
                 }
             }
-            val publishers = PublishersProvider(project, logger).get()
+            val publishers = PublishersProvider(project, logger, TestExecutor(), TestExecutor()).get()
             then("instance of InfluxDbPublisher is created") {
                 publishers.forAtLeastOne {
                     it is InfluxDbPublisher
@@ -46,7 +46,7 @@ class PublishersProviderTest : BehaviorSpec({
                 outputPublisher {
                 }
             }
-            val publishers = PublishersProvider(project, logger).get()
+            val publishers = PublishersProvider(project, logger, TestExecutor(), TestExecutor()).get()
             then("instance of OutputPublisher is created") {
                 publishers.forAtLeastOne {
                     it is OutputPublisher
@@ -61,7 +61,7 @@ class PublishersProviderTest : BehaviorSpec({
                     gexf = true
                 }
             }
-            val publishers = PublishersProvider(project, logger).get()
+            val publishers = PublishersProvider(project, logger, TestExecutor(), TestExecutor()).get()
             then("instance of TaskDependencyGraphPublisher is created") {
                 publishers.forAtLeastOne {
                     it is TaskDependencyGraphPublisher
@@ -74,7 +74,7 @@ class PublishersProviderTest : BehaviorSpec({
             talaiotExtension.publishers {
                 customPublisher(TestPublisher())
             }
-            val publishers = PublishersProvider(project, logger).get()
+            val publishers = PublishersProvider(project, logger, TestExecutor(), TestExecutor()).get()
             then("instance of CustomPublisher is created") {
                 publishers.forAtLeastOne {
                     it is TestPublisher
@@ -98,7 +98,7 @@ class PublishersProviderTest : BehaviorSpec({
                     dbName = ""
                 }
             }
-            val publishers = PublishersProvider(project, logger).get()
+            val publishers = PublishersProvider(project, logger, TestExecutor(), TestExecutor()).get()
             then("instance of all publishers are created") {
                 publishers.forAll {
                     it is TestPublisher


### PR DESCRIPTION
Executor was not properly finished at the end of the build. 
This PR includes changes to support the blocking thread at the end of the build. For heavy operations like GraphPublishers family we are using a final non-blocker thread. 

Tested in poor connectivity conditions with high latency values. 

closes #131 