### PR TITLE
including Custom Publisher in the sample

### DIFF
--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,4 +1,6 @@
 import com.cdsap.talaiot.logger.LogTracker
+import com.cdsap.talaiot.publisher.Publisher
+import com.cdsap.talaiot.entities.ExecutionReport
 
 repositories {
     jcenter()
@@ -12,8 +14,8 @@ plugins {
     id("talaiot") version "1.0.11-SNAPSHOT"
 }
 
-dependencies{
-    implementation ("org.jetbrains.kotlin:kotlin-stdlib:1.3.60")
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.3.60")
 }
 
 talaiot {
@@ -30,5 +32,13 @@ talaiot {
             taskMetricName = "task"
             buildMetricName = "build"
         }
+        customPublisher = CustomPublisher()
+    }
+}
+
+class CustomPublisher : Publisher {
+
+    override fun publish(report: ExecutionReport) {
+        println("[CustomPublisher] : Number of tasks = ${report.tasks?.size}")
     }
 }


### PR DESCRIPTION
doc has been updated with the new definition of the publish function with `ExecutionReport`(see  issue #138)

adding Custom Publisher in the sample project