### PR TITLE
Calculate cacheRatio using "unfilteredTasks" list instead of "tasks"

### DIFF
--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/entities/ExecutionReport.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/entities/ExecutionReport.kt
@@ -44,7 +44,7 @@ data class ExecutionReport(
      * Cache ratio of the tasks = tasks_from_cache / all_tasks
      */
     val cacheRatio: String?
-        get() = tasks?.let {
+        get() = unfilteredTasks?.let {
             it.count { taskLength -> taskLength.state == TaskMessageState.FROM_CACHE } / it.size.toDouble()
         }?.toString()
 

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/entities/ExecutionReportTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/entities/ExecutionReportTest.kt
@@ -1,0 +1,46 @@
+package com.cdsap.talaiot.entities
+
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.BehaviorSpec
+
+class ExecutionReportTest : BehaviorSpec({
+    given("An execution report and a list of tasks") {
+        val report = ExecutionReport()
+        val allTasks = listOf(
+            TaskLength(
+                ms = 1000L,
+                taskName = "task1",
+                taskPath = "module:task1",
+                state = TaskMessageState.EXECUTED,
+                module = "module",
+                taskDependencies = emptyList()
+            ),
+            TaskLength(
+                ms = 1000L,
+                taskName = "task2",
+                taskPath = "module:task2",
+                state = TaskMessageState.FROM_CACHE,
+                module = "module",
+                taskDependencies = emptyList()
+            )
+        )
+
+        `when`("all tasks are present") {
+            report.tasks = allTasks
+            report.unfilteredTasks = allTasks
+
+            then("cache ratio is 0.5") {
+                report.cacheRatio.shouldBe("0.5")
+            }
+        }
+
+        `when`("all tasks are filtered out") {
+            report.tasks = emptyList()
+            report.unfilteredTasks = allTasks
+
+            then("cache ratio is 0.5") {
+                report.cacheRatio.shouldBe("0.5")
+            }
+        }
+    }
+})


### PR DESCRIPTION
Like that we use list of all tasks that were executed and not only a subset of tasks.

* This value is more accurate because some tasks might be filtered out according to "filter" configuration
* Prevent "division by zero" in case when all tasks are filtered out and "tasks" list is empty

Fixes: https://github.com/cdsap/Talaiot/issues/140

Example project that showcases the error: https://github.com/MyDogTom/talaiot-filter-tasks-bug