### PR TITLE
Add filter option for builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Additionally, we are disabling the metrics for Git and Performance.
 | generateBuildId| Generation of unique identifier for each execution(disabled by default)   |
 | publishers     | Configuration to define where to submit the information of the build      |
 | metrics        | Additional information tracked during the execution of the task           |
-| filter         | Rules to filter the tasks to be reported                                  |
+| filter         | Rules to filter the build or the tasks to be reported                     |
 
     
 ### Publishers
@@ -321,11 +321,18 @@ talaiot {
  For every measurement done, Talaiot can filter the tasks tracked to be published. These filters don't apply to GraphPublishers:
  
  
- | Property      |      Description                                                                           |
- |---------------|--------------------------------------------------------------------------------------------|
- | tasks         |Configuration used to filter which tasks we want to exclude and include in the execution    |
- | module        |Configuration used to filter which modules we want to exclude and include in the execution  |
- | threshold     |Configuration used to define time execution ranges to filter tasks to be reported           |
+ | Property             |      Description                                                                             |
+ |----------------------|----------------------------------------------------------------------------------------------|
+ | tasks                |Configuration used to filter which tasks we want to exclude and include in the execution      |
+ | module               |Configuration used to filter which modules we want to exclude and include in the execution    |
+ | threshold            |Configuration used to define time execution ranges to filter tasks to be reported             |
+ 
+ For every measurement done, Talaiot can completely skip publishing process. These filters affect all publishers:
+ 
+ | Property             |      Description                                                                             |
+ |----------------------|----------------------------------------------------------------------------------------------|
+ | build.success        |Configuration used to skip publishing based on build success.                                 |
+ | build.requestedTasks |Configuration used to skip publishing based on what was the requested task.                   |
  
  
  Example:
@@ -339,6 +346,13 @@ talaiot {
       }
       threshold {
           minExecutionTime = 10
+      }
+      build {
+          success = true
+          requestedTasks {
+              includes = arrayOf(":app:assemble.*")
+              excludes = arrayOf(":app:generate.*")
+          }
       }
   }
  ```

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/BuildFilterConfiguration.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/BuildFilterConfiguration.kt
@@ -1,0 +1,18 @@
+package com.cdsap.talaiot.configuration
+
+import com.cdsap.talaiot.filter.StringFilter
+import groovy.lang.Closure
+
+class BuildFilterConfiguration {
+    var success: Boolean? = null
+    var requestedTasks: StringFilter = StringFilter()
+
+    fun requestedTasks(configuration: StringFilter.() -> Unit) {
+        requestedTasks.also(configuration)
+    }
+
+    fun requestedTasks(closure: Closure<*>) {
+        closure.delegate = requestedTasks
+        closure.call()
+    }
+}

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/filter/BuildFilterProcessor.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/filter/BuildFilterProcessor.kt
@@ -1,0 +1,23 @@
+package com.cdsap.talaiot.filter
+
+import com.cdsap.talaiot.configuration.BuildFilterConfiguration
+import com.cdsap.talaiot.entities.ExecutionReport
+import com.cdsap.talaiot.logger.LogTracker
+
+class BuildFilterProcessor(
+    val logTracker: LogTracker,
+    val filter: BuildFilterConfiguration
+) {
+
+    fun shouldPublishBuild(report: ExecutionReport): Boolean {
+        val successAllowsPublishing = report.success == filter.success || filter.success == null
+        return if (successAllowsPublishing) {
+            val processor = StringFilterProcessor(filter.requestedTasks, logTracker)
+            return report.requestedTasks?.split(" ")?.any {
+                processor.matches(it)
+            } ?: true
+        } else {
+            false
+        }
+    }
+}

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/publisher/TalaiotPublisherImpl.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/publisher/TalaiotPublisherImpl.kt
@@ -1,8 +1,10 @@
 package com.cdsap.talaiot.publisher
 
 import com.cdsap.talaiot.TalaiotExtension
+import com.cdsap.talaiot.configuration.BuildFilterConfiguration
 import com.cdsap.talaiot.entities.ExecutionReport
 import com.cdsap.talaiot.entities.TaskLength
+import com.cdsap.talaiot.filter.BuildFilterProcessor
 import com.cdsap.talaiot.filter.TaskFilterProcessor
 import com.cdsap.talaiot.logger.LogTracker
 import com.cdsap.talaiot.provider.Provider
@@ -23,6 +25,7 @@ class TalaiotPublisherImpl(
     private val publisherProvider: Provider<List<Publisher>>
 ) : TalaiotPublisher {
     private val taskFilterProcessor: TaskFilterProcessor = TaskFilterProcessor(logger, extension.filter)
+    private val buildFilterProcessor: BuildFilterProcessor = BuildFilterProcessor(logger, extension.filter?.build ?: BuildFilterConfiguration())
 
     override fun publish(
         taskLengthList: MutableList<TaskLength>,
@@ -48,8 +51,10 @@ class TalaiotPublisherImpl(
             this.estimateCriticalPath()
         }
 
-        publisherProvider.get().forEach {
-            it.publish(report)
+        if (buildFilterProcessor.shouldPublishBuild(report)) {
+            publisherProvider.get().forEach {
+                it.publish(report)
+            }
         }
     }
 }

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/filter/BuildFilterProcessorTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/filter/BuildFilterProcessorTest.kt
@@ -1,0 +1,112 @@
+package com.cdsap.talaiot.filter
+
+import com.cdsap.talaiot.configuration.BuildFilterConfiguration
+import com.cdsap.talaiot.entities.ExecutionReport
+import com.cdsap.talaiot.logger.TestLogTrackerRecorder
+import io.kotlintest.matchers.boolean.shouldBeFalse
+import io.kotlintest.matchers.boolean.shouldBeTrue
+import io.kotlintest.specs.BehaviorSpec
+
+class BuildFilterProcessorTest: BehaviorSpec({
+    given("A logger") {
+        val logTracker = TestLogTrackerRecorder
+
+        `when`("Configuration is not specified") {
+            val configuration = BuildFilterConfiguration().apply {
+
+            }
+            val buildFilterProcessor = BuildFilterProcessor(logTracker, configuration)
+
+            then("failed build is published"){
+                val report = ExecutionReport(success = false)
+                buildFilterProcessor.shouldPublishBuild(report).shouldBeTrue()
+            }
+
+            then("successful build is published"){
+                val report = ExecutionReport(success = true, requestedTasks = "app:taskA")
+                buildFilterProcessor.shouldPublishBuild(report).shouldBeTrue()
+            }
+        }
+
+        `when`("configure for only successful builds") {
+            val configuration = BuildFilterConfiguration().apply {
+                success = true
+            }
+            val buildFilterProcessor = BuildFilterProcessor(logTracker, configuration)
+
+            then("failed build is not published"){
+                val report = ExecutionReport(success = false)
+                buildFilterProcessor.shouldPublishBuild(report).shouldBeFalse()
+            }
+
+            then("successful build is published"){
+                val report = ExecutionReport(success = true, requestedTasks = "app:taskA")
+                buildFilterProcessor.shouldPublishBuild(report).shouldBeTrue()
+            }
+        }
+
+        `when`("configure to exclude tasks") {
+            val configuration = BuildFilterConfiguration().apply {
+                requestedTasks.excludes = arrayOf(":app:taskA", ":app:taskB")
+            }
+            val buildFilterProcessor = BuildFilterProcessor(logTracker, configuration)
+
+            then("do not publish if all requested tasks excluded"){
+                val report = ExecutionReport(success = false, requestedTasks = ":app:taskA :app:taskB")
+                buildFilterProcessor.shouldPublishBuild(report).shouldBeFalse()
+            }
+
+            then("publish if at least one requested task is not filtered out"){
+                val report = ExecutionReport(success = true, requestedTasks = ":app:taskC")
+                buildFilterProcessor.shouldPublishBuild(report).shouldBeTrue()
+            }
+        }
+
+        `when`("configure to exclude tasks via regex") {
+            val configuration = BuildFilterConfiguration().apply {
+                requestedTasks.excludes = arrayOf(":app:task.*")
+            }
+            val buildFilterProcessor = BuildFilterProcessor(logTracker, configuration)
+
+            then("do not publish if all requested tasks excluded"){
+                val report = ExecutionReport(success = false, requestedTasks = ":app:taskA :app:taskB")
+                buildFilterProcessor.shouldPublishBuild(report).shouldBeFalse()
+            }
+
+            then("publish if at least one requested task is not filtered out"){
+                val report = ExecutionReport(success = true, requestedTasks = ":module:taskC")
+                buildFilterProcessor.shouldPublishBuild(report).shouldBeTrue()
+            }
+        }
+
+        `when`("configure to include and tasks") {
+            val configuration = BuildFilterConfiguration().apply {
+                requestedTasks.includes = arrayOf(":app:assembleDebug")
+            }
+            val buildFilterProcessor = BuildFilterProcessor(logTracker, configuration)
+
+            then("do not publish if requested task doesn't match included"){
+                val report = ExecutionReport(success = false, requestedTasks = ":app:taskA :app:taskB")
+                buildFilterProcessor.shouldPublishBuild(report).shouldBeFalse()
+            }
+
+            then("publish if at least one requested task is not filtered out"){
+                val report = ExecutionReport(success = true, requestedTasks = ":app:assembleDebug")
+                buildFilterProcessor.shouldPublishBuild(report).shouldBeTrue()
+            }
+        }
+
+        `when`("configure to include and exclude tasks") {
+            val configuration = BuildFilterConfiguration().apply {
+                requestedTasks.excludes = arrayOf(":app:task*")
+                requestedTasks.includes = arrayOf(":app:taskA")
+            }
+            val buildFilterProcessor = BuildFilterProcessor(logTracker, configuration)
+
+            then("include has priority and report is published "){
+                val report = ExecutionReport(success = false, requestedTasks = ":app:taskA :app:taskB")
+                buildFilterProcessor.shouldPublishBuild(report).shouldBeTrue()
+            }
+        }
+    }
+})

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/publisher/TalaiotPublisherImplTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/publisher/TalaiotPublisherImplTest.kt
@@ -8,9 +8,11 @@ import com.cdsap.talaiot.entities.TaskLength
 import com.cdsap.talaiot.entities.TaskMessageState
 import com.cdsap.talaiot.logger.LogTrackerImpl
 import com.cdsap.talaiot.provider.Provider
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import io.kotlintest.specs.BehaviorSpec
 import org.gradle.api.Project
@@ -175,6 +177,191 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 })
             }
         }
+
+        `when`("build filter configured to publish only successful build") {
+            val project: Project = mock()
+            val extension = TalaiotExtension(project).apply {
+                filter {
+                    build {
+                        success = true
+                    }
+                }
+                publishers {
+                    jsonPublisher = true
+                }
+            }
+            setUpMockExtension(project, extension)
+
+            then("successful build is published") {
+                val publisher: Publisher = mock()
+                val publisherProvider: Provider<List<Publisher>> = SimpleProvider(listOf(publisher))
+
+                TalaiotPublisherImpl(extension, logger, getMetricsProvider(), publisherProvider).publish(
+                    taskLengthList = getTasks(),
+                    startMs = 0,
+                    configuraionMs = 100,
+                    endMs = 200,
+                    success = true
+                )
+
+                verify(publisher).publish(any())
+            }
+
+            then("failed build is not published") {
+                val publisher: Publisher = mock()
+                val publisherProvider: Provider<List<Publisher>> = SimpleProvider(listOf(publisher))
+
+                TalaiotPublisherImpl(extension, logger, getMetricsProvider(), publisherProvider).publish(
+                    taskLengthList = getTasks(),
+                    startMs = 0,
+                    configuraionMs = 100,
+                    endMs = 200,
+                    success = false
+                )
+
+                verifyZeroInteractions(publisher)
+            }
+        }
+
+        `when`("build filter configured to exclude requested tasks") {
+            val project: Project = mock()
+            val extension = TalaiotExtension(project).apply {
+                filter {
+                    build {
+                        requestedTasks {
+                            excludes = arrayOf(":module:taskA")
+                        }
+                    }
+                }
+            }
+            setUpMockExtension(project, extension)
+
+            then("build with a different task is published") {
+                val publisher: Publisher = mock()
+                val publisherProvider: Provider<List<Publisher>> = SimpleProvider(listOf(publisher))
+                val report = ExecutionReport(requestedTasks = ":module:taskB")
+
+                TalaiotPublisherImpl(extension, logger, SimpleProvider(report), publisherProvider).publish(
+                    taskLengthList = getTasks(),
+                    startMs = 0,
+                    configuraionMs = 100,
+                    endMs = 200,
+                    success = false
+                )
+
+                verify(publisher).publish(any())
+            }
+
+            then("build with all tasks filtered out is not published") {
+                val publisher: Publisher = mock()
+                val publisherProvider: Provider<List<Publisher>> = SimpleProvider(listOf(publisher))
+                val report = ExecutionReport(requestedTasks = ":module:taskA")
+
+                TalaiotPublisherImpl(extension, logger, SimpleProvider(report), publisherProvider).publish(
+                    taskLengthList = getTasks(),
+                    startMs = 0,
+                    configuraionMs = 100,
+                    endMs = 200,
+                    success = true
+                )
+
+                verifyZeroInteractions(publisher)
+            }
+        }
+
+        `when`("build filter configured to include requested tasks") {
+            val project: Project = mock()
+            val extension = TalaiotExtension(project).apply {
+                filter {
+                    build {
+                        requestedTasks {
+                            includes = arrayOf(":module:taskA")
+                        }
+                    }
+                }
+            }
+            setUpMockExtension(project, extension)
+
+            then("build with a different task is not published") {
+                val publisher: Publisher = mock()
+                val publisherProvider: Provider<List<Publisher>> = SimpleProvider(listOf(publisher))
+                val report = ExecutionReport(requestedTasks = ":module:taskB")
+
+                TalaiotPublisherImpl(extension, logger, SimpleProvider(report), publisherProvider).publish(
+                    taskLengthList = getTasks(),
+                    startMs = 0,
+                    configuraionMs = 100,
+                    endMs = 200,
+                    success = false
+                )
+
+                verifyZeroInteractions(publisher)
+            }
+
+            then("build with the same task is published") {
+                val publisher: Publisher = mock()
+                val publisherProvider: Provider<List<Publisher>> = SimpleProvider(listOf(publisher))
+                val report = ExecutionReport(requestedTasks = ":module:taskA")
+
+                TalaiotPublisherImpl(extension, logger, SimpleProvider(report), publisherProvider).publish(
+                    taskLengthList = getTasks(),
+                    startMs = 0,
+                    configuraionMs = 100,
+                    endMs = 200,
+                    success = true
+                )
+
+                verify(publisher).publish(any())
+            }
+        }
+
+        `when`("build filter configured to include and exclude tasks") {
+            val project: Project = mock()
+            val extension = TalaiotExtension(project).apply {
+                filter {
+                    build {
+                        success = true
+                        requestedTasks {
+                            excludes = arrayOf(":module:taskB")
+                            includes = arrayOf(":module:taskA")
+                        }
+                    }
+                }
+            }
+            setUpMockExtension(project, extension)
+
+            then("build with at least one task included is published") {
+                val publisher: Publisher = mock()
+                val publisherProvider: Provider<List<Publisher>> = SimpleProvider(listOf(publisher))
+                val report = ExecutionReport(requestedTasks = ":module:taskA :module:taskB")
+
+                TalaiotPublisherImpl(extension, logger, SimpleProvider(report), publisherProvider).publish(
+                    taskLengthList = getTasks(),
+                    startMs = 0,
+                    configuraionMs = 100,
+                    endMs = 200,
+                    success = true
+                )
+
+                verify(publisher).publish(any())
+            }
+
+            then("build with all tasks filtered out is not published") {
+                val publisher: Publisher = mock()
+                val publisherProvider: Provider<List<Publisher>> = SimpleProvider(listOf(publisher))
+                val report = ExecutionReport(requestedTasks = ":module:taskB")
+
+                TalaiotPublisherImpl(extension, logger, SimpleProvider(report), publisherProvider).publish(
+                    taskLengthList = getTasks(),
+                    startMs = 0,
+                    configuraionMs = 100,
+                    endMs = 200,
+                    success = true
+                )
+
+                verifyZeroInteractions(publisher)
+            }
+        }
     }
 
 })
@@ -187,10 +374,8 @@ private fun setUpMockExtension(project: Project, extension: TalaiotExtension) {
     whenever(extensionContainer.getByName("talaiot")).thenReturn(extension)
 }
 
-private fun getMetricsProvider(): Provider<ExecutionReport> {
-    return object: Provider<ExecutionReport> {
-        override fun get() = ExecutionReport()
-    }
+private fun getMetricsProvider(report: ExecutionReport = ExecutionReport()): Provider<ExecutionReport> {
+    return SimpleProvider(report)
 }
 
 private fun metricsConfiguration() = MetricsConfiguration()
@@ -218,3 +403,8 @@ private fun getSingleTask() = TaskLength(
     taskDependencies = emptyList()
 )
 
+private class SimpleProvider<T>(private val value: T) : Provider<T> {
+    override fun get(): T {
+        return value
+    }
+}


### PR DESCRIPTION
Allows to specify if build should be published or not.
Filter options:
* build result
* requestedTasks

Implements: https://github.com/cdsap/Talaiot/issues/141

PS: sorry for the delay with PR.