### PR TITLE
adding Environment metrics in the default configuration

### DIFF
--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/MetricsConfiguration.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/MetricsConfiguration.kt
@@ -85,6 +85,14 @@ class MetricsConfiguration {
         this@MetricsConfiguration
     }
 
+    fun environment() = metrics.run {
+        add(OsManufacturerMetric())
+        add(HostnameMetric())
+        add(PublicIpMetric())
+        add(DefaultCharsetMetric())
+        this@MetricsConfiguration
+    }
+
     fun performance() = metrics.run {
         add(UserMetric())
         add(OsMetric())
@@ -146,6 +154,7 @@ class MetricsConfiguration {
             performance()
             gradleSwitches()
             git()
+            environment()
         }
 
         if (generateBuildId) {

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/metrics/SimpleMetrics.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/metrics/SimpleMetrics.kt
@@ -8,6 +8,7 @@ import org.gradle.api.internal.GradleInternal
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.internal.scan.scopeids.BuildScanScopeIds
 import oshi.SystemInfo
+import java.net.InetAddress
 import java.nio.charset.Charset
 import java.util.*
 
@@ -22,7 +23,7 @@ class UserMetric : SimpleMetric<String>(
 class OsMetric :
     SimpleMetric<String>(
         provider = { "${OperatingSystem.current().name}-${OperatingSystem.current().version}" },
-        assigner = { report, value -> report.environment.osVersion = value}
+        assigner = { report, value -> report.environment.osVersion = value }
     )
 
 class BuildIdMetric : SimpleMetric<String>(
@@ -40,7 +41,7 @@ class BuildIdMetric : SimpleMetric<String>(
  * That is, all “nested” builds (in terms of GradleLauncher etc.) share the same build ID.
  *
  * This ID is, by definition, not persistent.
-*/
+ */
 class GradleBuildInvocationIdMetric : GradleMetric<String>(
     provider = { project: Project -> (project.gradle as GradleInternal).services[BuildScanScopeIds::class.java].buildInvocationId },
     assigner = { report, value -> report.buildInvocationId = value }
@@ -56,17 +57,9 @@ class RamAvailableMetric : SimpleMetric<String>(
     assigner = { report, value -> report.environment.totalRamAvailableBytes = value }
 )
 
-/**
- * see https://docs.oracle.com/javase/9/docs/api/java/lang/Runtime.html#version--
- */
-class JavaRuntimeMetric : SimpleMetric<String>(
-    provider = { TODO("implement") },
-    assigner = { report, value -> report.environment.javaRuntime = value }
-)
-
 class JavaVmNameMetric : SimpleMetric<String>(
     provider = { System.getProperty("java.runtime.version") },
-    assigner = { report, value -> report.environment.javaVmName = value}
+    assigner = { report, value -> report.environment.javaVmName = value }
 )
 
 class LocaleMetric : SimpleMetric<String>(
@@ -80,7 +73,7 @@ class OsManufacturerMetric : SimpleMetric<String>(
 )
 
 class HostnameMetric : SimpleMetric<String>(
-    provider = { SystemInfo().operatingSystem.manufacturer },
+    provider = { InetAddress.getLocalHost().hostName },
     assigner = { report, value -> report.environment.hostname = value }
 )
 

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/publisher/ElasticSearchPublisher.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/publisher/ElasticSearchPublisher.kt
@@ -100,8 +100,10 @@ class ElasticSearchPublisher(
             report.environment.gradleVersion?.let { "gradleVersion" to it }
             report.environment.gitBranch?.let { "gitBranch" to it }
             report.environment.gitUser?.let { "gitUser" to it }
+            report.environment.hostname?.let { "hostname" to it }
+            report.environment.osManufacturer?.let { "osManufacturer" to it }
+            report.environment.publicIp?.let { "publicIp" to it }
             report.cacheRatio?.let { "cacheRatio" to it.toDouble() }
-
             report.beginMs?.let { "start" to it.toDouble() }
             report.rootProject?.let { "rootProject" to it }
             report.requestedTasks?.let { "requestedTasks" to it }

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/publisher/InfluxDbPublisher.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/publisher/InfluxDbPublisher.kt
@@ -154,7 +154,6 @@ class InfluxDbPublisher(
                 report.environment.javaXmxBytes?.let { addField("javaXmxBytes", it.toLong()) }
                 report.environment.javaMaxPermSize?.let { addField("javaMaxPermSize", it.toLong()) }
                 report.environment.totalRamAvailableBytes?.let { addField("totalRamAvailableBytes", it.toLong()) }
-
                 report.environment.cpuCount?.let { addField("cpuCount", it.toLong()) }
                 report.environment.locale?.let { addField("locale", it) }
                 report.environment.username?.let { addField("username", it) }
@@ -164,8 +163,10 @@ class InfluxDbPublisher(
                 report.environment.gradleVersion?.let { addField("gradleVersion", it) }
                 report.environment.gitBranch?.let { addField("gitBranch", it) }
                 report.environment.gitUser?.let { addField("gitUser", it) }
+                report.environment.hostname?.let { addField("hostname", it) }
+                report.environment.osManufacturer?.let { addField("osManufacturer", it) }
+                report.environment.publicIp?.let { addField("publicIp", it) }
                 report.cacheRatio?.let { addField("cacheRatio", it.toDouble()) }
-
                 report.beginMs?.let { addField("start", it.toDouble()) }
                 report.rootProject?.let { addField("rootProject", it) }
                 report.requestedTasks?.let { addField("requestedTasks", it) }

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/publisher/rethinkdb/RethinkDbPublisher.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/publisher/rethinkdb/RethinkDbPublisher.kt
@@ -185,12 +185,14 @@ class RethinkDbPublisher(
             environment.cpuCount?.let { map["cpuCount"] = it.toLong() }
             environment.locale?.let { map["locale"] = it }
             environment.username?.let { map["username"] = it }
-            environment.publicIp?.let { map["publicIp"] = it }
             environment.defaultChartset?.let { map["defaultCharset"] = it }
             environment.ideVersion?.let { map["ideVersion"] = it }
             environment.gradleVersion?.let { map["gradleVersion"] = it }
             environment.gitBranch?.let { map["gitBranch"] = it }
             environment.gitUser?.let { map["gitUser"] = it }
+            environment.hostname?.let { map["hostname" ] = it }
+            environment.osManufacturer?.let { map["osManufacturer"] = it }
+            environment.publicIp?.let { map["publicIp"] = it }
         }
         report.apply {
             cacheRatio?.let { map["cacheRatio"] = it.toDouble() }

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
@@ -6,52 +6,54 @@ import io.kotlintest.specs.BehaviorSpec
 
 class MetricsConfigurationTest : BehaviorSpec({
     given("metrics configuration") {
-
         `when`("defaults are used") {
             val metricsConfiguration = MetricsConfiguration()
             val metrics = metricsConfiguration.build()
-
-            assert(metrics.count { it is RootProjectNameMetric } == 1)
-            assert(metrics.count { it is GradleRequestedTasksMetric } == 1)
-            assert(metrics.count { it is GradleVersionMetric } == 1)
+            then("RootProject, GradleRequested and GradleVersion are included") {
+                assert(metrics.count { it is RootProjectNameMetric } == 1)
+                assert(metrics.count { it is GradleRequestedTasksMetric } == 1)
+                assert(metrics.count { it is GradleVersionMetric } == 1)
+            }
         }
-        
         `when`("environment metrics are configured") {
             val metricsConfiguration = MetricsConfiguration()
             val metrics = metricsConfiguration.environment().build()
-            assert(metrics.count { it is HostnameMetric } == 1)
-            assert(metrics.count { it is OsManufacturerMetric } == 1)
-            assert(metrics.count { it is PublicIpMetric } == 1)
-            assert(metrics.count { it is DefaultCharsetMetric } == 1)
+            then("HostnameMetric, OsManufacturerMetric, PublicIpMetric and DefaultCharsetMetric are included") {
+                assert(metrics.count { it is HostnameMetric } == 1)
+                assert(metrics.count { it is OsManufacturerMetric } == 1)
+                assert(metrics.count { it is PublicIpMetric } == 1)
+                assert(metrics.count { it is DefaultCharsetMetric } == 1)
+            }
         }
-
         `when`("performance metrics are configured") {
             val metricsConfiguration = MetricsConfiguration()
             val metrics = metricsConfiguration.performance().build()
-
-            assert(metrics.count { it is ProcessorCountMetric } == 1)
+            then("ProcessorCountMetric is included") {
+                assert(metrics.count { it is ProcessorCountMetric } == 1)
+            }
         }
-
         `when`("git metrics are configured") {
             val metricsConfiguration = MetricsConfiguration()
             val metrics = metricsConfiguration.git().build()
-
-            assert(metrics.count { it is GitBranchMetric } == 1 &&
-                    metrics.count { it is GitUserMetric } == 1)
+            then("GitBranchMetric and GitUserMetric are included") {
+                assert(metrics.count { it is GitBranchMetric } == 1 &&
+                        metrics.count { it is GitUserMetric } == 1)
+            }
         }
-
         `when`("build Id generation is disabled in the default behaviour") {
             val metricsConfiguration = MetricsConfiguration()
             val metrics = metricsConfiguration.performance().build()
-
-            assert(metrics.count { it is BuildIdMetric } == 0)
+            then("BuildIdMetric is disabled") {
+                assert(metrics.count { it is BuildIdMetric } == 0)
+            }
         }
         `when`("build Id generation is enabled") {
             val metricsConfiguration = MetricsConfiguration()
             metricsConfiguration.generateBuildId = true
             val metrics = metricsConfiguration.performance().build()
-
-            assert(metrics.count { it is BuildIdMetric } == 1)
+            then("BuildIdMetric is included") {
+                assert(metrics.count { it is BuildIdMetric } == 1)
+            }
         }
     }
 })

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
@@ -14,6 +14,8 @@ class MetricsConfigurationTest : BehaviorSpec({
             assert(metrics.count { it is RootProjectNameMetric } == 1)
             assert(metrics.count { it is GradleRequestedTasksMetric } == 1)
             assert(metrics.count { it is GradleVersionMetric } == 1)
+            assert(metrics.count { it is HostnameMetric } == 1)
+            assert(metrics.count { it is OsManufacturerMetric } == 1)
         }
 
         `when`("performance metrics are configured") {

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
@@ -18,8 +18,7 @@ class MetricsConfigurationTest : BehaviorSpec({
         
         `when`("environment metrics are configured") {
             val metricsConfiguration = MetricsConfiguration()
-            val metrics = metricsConfiguration.performance().build()
-            
+            val metrics = metricsConfiguration.environment().build()
             assert(metrics.count { it is HostnameMetric } == 1)
             assert(metrics.count { it is OsManufacturerMetric } == 1)
             assert(metrics.count { it is PublicIpMetric } == 1)


### PR DESCRIPTION
Fixing #154 

Included new configuration environment using:
```
OsManufacturerMetric()
HostnameMetric()
PublicIpMetric()
```
Changed the method to retrieve the hostname
```
 InetAddress.getLocalHost().hostName
```
Updated InfluxDbPublisher and RethinkPublisher