### PR TITLE
Make MetricsConfiguration Groovy friendly

### DIFF
--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -39,8 +39,8 @@ talaiot {
 
     metrics {
         // Talaiot provides a few methods to add a group of metrics at once:
-        default()
-        git()
+        defaultMetrics()
+        gitMetrics()
 
         // You can also add your own custom Metric objects:
         customMetrics(

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/MetricsConfiguration.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/MetricsConfiguration.kt
@@ -7,16 +7,20 @@ import com.cdsap.talaiot.metrics.base.Metric
 /**
  * Configuration for the Metrics extensions
  *
+ * ```
  * metrics{
- *   default()
- *   git()
- *   performance()
- *   gradleSwitches()
+ *   defaultMetrics()
+ *   gitMetrics()
+ *   performanceMetrics()
+ *   gradleSwitchesMetrics()
  * }
+ * ```
  *
- * By default [default] is called unless user has specified anything at all in this configuration.
+ * By default Talaiot executes
+ *  [defaultMetrics], [performanceMetrics], [gradleSwitchesMetrics], [gitMetrics] and [environmentMetrics] metrics,
+ *  unless user manually specified which metrics should be executed.
  *
- * Default includes:
+ * [defaultMetrics] includes:
  *  [RootProjectNameMetric]
  *  [GradleRequestedTasksMetric]
  *  [GradleVersionMetric]
@@ -24,11 +28,11 @@ import com.cdsap.talaiot.metrics.base.Metric
  *  [GradleBuildCachePushEnabled]
  *  [GradleScanLinkMetric]
  *
- * Git includes:
+ * [gitMetrics] includes:
  *  [GitUserMetric]
  *  [GitBranchMetric]
  *
- * Performance includes:
+ * [performanceMetrics] includes:
  *  [UserMetric]
  *  [OsMetric]
  *  [ProcessorCountMetric]
@@ -40,7 +44,7 @@ import com.cdsap.talaiot.metrics.base.Metric
  *  [JvmXmxMetric]
  *  [JvmMaxPermSizeMetric]
  *
- * Gradle switches includes:
+ * [gradleSwitchesMetrics] includes:
  *  [GradleSwitchCachingMetric]
  *  [GradleSwitchBuildScanMetric]
  *  [GradleSwitchParallelMetric]
@@ -49,6 +53,12 @@ import com.cdsap.talaiot.metrics.base.Metric
  *  [GradleSwitchRefreshDependenciesMetric]
  *  [GradleSwitchRerunTasksMetric]
  *  [GradleSwitchDaemonMetric]
+ *
+ * [environmentMetrics] includes:
+ *  [OsManufacturerMetric]
+ *  [HostnameMetric]
+ *  [PublicIpMetric]
+ *  [DefaultCharsetMetric]
  *
  *  If you want to define custom metrics:
  *
@@ -76,57 +86,64 @@ class MetricsConfiguration {
      */
     var generateBuildId = false
 
-    private var metrics: MutableList<Metric<*, *>> = mutableListOf()
+    private var metrics: MutableSet<Metric<*, *>> = mutableSetOf()
 
-    fun default() = metrics.run {
-        add(RootProjectNameMetric())
-        add(GradleRequestedTasksMetric())
-        add(GradleVersionMetric())
-        add(GradleBuildCacheModeMetric())
-        add(GradleBuildCachePushEnabled())
-        add(GradleScanLinkMetric())
-
-        this@MetricsConfiguration
+    fun defaultMetrics() {
+        with(metrics){
+            add(RootProjectNameMetric())
+            add(GradleRequestedTasksMetric())
+            add(GradleVersionMetric())
+            add(GradleBuildCacheModeMetric())
+            add(GradleBuildCachePushEnabled())
+            add(GradleScanLinkMetric())
+        }
     }
 
-    fun git() = metrics.run {
-        add(GitUserMetric())
-        add(GitBranchMetric())
-        this@MetricsConfiguration
+    fun gitMetrics() {
+        with(metrics) {
+            add(GitUserMetric())
+            add(GitBranchMetric())
+        }
     }
 
-    fun environment() = metrics.run {
-        add(OsManufacturerMetric())
-        add(HostnameMetric())
-        add(PublicIpMetric())
-        add(DefaultCharsetMetric())
-        this@MetricsConfiguration
+    fun environmentMetrics() {
+        with(metrics) {
+            add(OsManufacturerMetric())
+            add(HostnameMetric())
+            add(PublicIpMetric())
+            add(DefaultCharsetMetric())
+
+        }
     }
 
-    fun performance() = metrics.run {
-        add(UserMetric())
-        add(OsMetric())
-        add(ProcessorCountMetric())
-        add(RamAvailableMetric())
-        add(JavaVmNameMetric())
-        add(LocaleMetric())
-        add(GradleMaxWorkersMetric())
-        add(JvmXmsMetric())
-        add(JvmXmxMetric())
-        add(JvmMaxPermSizeMetric())
-        this@MetricsConfiguration
+    fun performanceMetrics() {
+        with(metrics) {
+            add(UserMetric())
+            add(OsMetric())
+            add(ProcessorCountMetric())
+            add(RamAvailableMetric())
+            add(JavaVmNameMetric())
+            add(LocaleMetric())
+            add(GradleMaxWorkersMetric())
+            add(JvmXmsMetric())
+            add(JvmXmxMetric())
+            add(JvmMaxPermSizeMetric())
+
+        }
     }
 
-    fun gradleSwitches() = metrics.run {
-        add(GradleSwitchCachingMetric())
-        add(GradleSwitchBuildScanMetric())
-        add(GradleSwitchParallelMetric())
-        add(GradleSwitchConfigureOnDemandMetric())
-        add(GradleSwitchDryRunMetric())
-        add(GradleSwitchRefreshDependenciesMetric())
-        add(GradleSwitchRerunTasksMetric())
-        add(GradleSwitchDaemonMetric())
-        this@MetricsConfiguration
+    fun gradleSwitchesMetrics() {
+        with(metrics) {
+            add(GradleSwitchCachingMetric())
+            add(GradleSwitchBuildScanMetric())
+            add(GradleSwitchParallelMetric())
+            add(GradleSwitchConfigureOnDemandMetric())
+            add(GradleSwitchDryRunMetric())
+            add(GradleSwitchRefreshDependenciesMetric())
+            add(GradleSwitchRerunTasksMetric())
+            add(GradleSwitchDaemonMetric())
+
+        }
     }
 
     /**
@@ -208,21 +225,21 @@ class MetricsConfiguration {
         }
     }
 
-    internal fun build(): MutableList<Metric<*, *>> {
+    internal fun build(): List<Metric<*, *>> {
         // If there was any customization then we assume that user populated everything manually, otherwise defaults
         if (metrics.isEmpty()) {
-            default()
-            performance()
-            gradleSwitches()
-            git()
-            environment()
+            defaultMetrics()
+            performanceMetrics()
+            gradleSwitchesMetrics()
+            gitMetrics()
+            environmentMetrics()
         }
 
         if (generateBuildId) {
             metrics.add(BuildIdMetric())
         }
 
-        return metrics
+        return metrics.toList()
     }
 
     private fun createSimpleBuildMetric(pair: Pair<String, String>): SimpleMetric<String> {

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/metrics/CustomMetricsTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/metrics/CustomMetricsTest.kt
@@ -38,7 +38,7 @@ class CustomMetricsTest : BehaviorSpec({
         `when`("defaults and custom metrics are used") {
             val metricsConfiguration = MetricsConfiguration()
             val metrics = metricsConfiguration.run {
-                default()
+                defaultMetrics()
                 customMetrics(
                     KotlinVersionMetric()
                 )

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
@@ -16,8 +16,8 @@ class MetricsConfigurationTest : BehaviorSpec({
             }
         }
         `when`("environment metrics are configured") {
-            val metricsConfiguration = MetricsConfiguration()
-            val metrics = metricsConfiguration.environment().build()
+            val metricsConfiguration = MetricsConfiguration().apply { environmentMetrics() }
+            val metrics = metricsConfiguration.build()
             then("HostnameMetric, OsManufacturerMetric, PublicIpMetric and DefaultCharsetMetric are included") {
                 assert(metrics.count { it is HostnameMetric } == 1)
                 assert(metrics.count { it is OsManufacturerMetric } == 1)
@@ -26,31 +26,31 @@ class MetricsConfigurationTest : BehaviorSpec({
             }
         }
         `when`("performance metrics are configured") {
-            val metricsConfiguration = MetricsConfiguration()
-            val metrics = metricsConfiguration.performance().build()
+            val metricsConfiguration = MetricsConfiguration().apply { performanceMetrics() }
+            val metrics = metricsConfiguration.build()
             then("ProcessorCountMetric is included") {
                 assert(metrics.count { it is ProcessorCountMetric } == 1)
             }
         }
         `when`("git metrics are configured") {
-            val metricsConfiguration = MetricsConfiguration()
-            val metrics = metricsConfiguration.git().build()
+            val metricsConfiguration = MetricsConfiguration().apply { gitMetrics() }
+            val metrics = metricsConfiguration.build()
             then("GitBranchMetric and GitUserMetric are included") {
                 assert(metrics.count { it is GitBranchMetric } == 1 &&
                         metrics.count { it is GitUserMetric } == 1)
             }
         }
         `when`("build Id generation is disabled in the default behaviour") {
-            val metricsConfiguration = MetricsConfiguration()
-            val metrics = metricsConfiguration.performance().build()
+            val metricsConfiguration = MetricsConfiguration().apply { performanceMetrics() }
+            val metrics = metricsConfiguration.build()
             then("BuildIdMetric is disabled") {
                 assert(metrics.count { it is BuildIdMetric } == 0)
             }
         }
         `when`("build Id generation is enabled") {
-            val metricsConfiguration = MetricsConfiguration()
+            val metricsConfiguration = MetricsConfiguration().apply { performanceMetrics() }
             metricsConfiguration.generateBuildId = true
-            val metrics = metricsConfiguration.performance().build()
+            val metrics = metricsConfiguration.build()
             then("BuildIdMetric is included") {
                 assert(metrics.count { it is BuildIdMetric } == 1)
             }


### PR DESCRIPTION
Problem: `default()` cannot be called from Groovy because it overlaps either with Groovy reserved method or with method generated by Gradle.

This PR:
* Solves the problem by renaming `default()` to `defaultMetrics`. Similar name pattern applied to other methods: `git()`, `performance()`, `gradleSwitches()`, `environment()`.
* Changed return type of every such method from `MetricsConfiguration` to `Unit`. I think it's redundant since I couldn't find any usage of that and couldn't come up with a valid use case.
* Changes type of `metrics` variable from `MutableList` to `MutableSet` in order to prevent having same metric specified more than once.
* Adjustment to the `MetricsConfiguration` class documentation to reflect actual implementation.