### PR TITLE
Adding BuildCacheRemoteLoadBuildOperationTypeTest and Redis Container

### DIFF
--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/e2e/BuildCacheRemoteLoadBuildOperationTypeTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/e2e/BuildCacheRemoteLoadBuildOperationTypeTest.kt
@@ -1,0 +1,164 @@
+package com.cdsap.talaiot.e2e
+
+import com.cdsap.talaiot.publisher.KRedisContainer
+import com.cdsap.talaiot.publisher.graphpublisher.KInfluxDBContainer
+import io.kotlintest.Spec
+import io.kotlintest.specs.BehaviorSpec
+import junit.framework.Assert.assertTrue
+import org.gradle.testkit.runner.GradleRunner
+import org.influxdb.dto.Query
+
+/**
+ * E2E Test to check the if the event BuildCacheRemoteLoadBuildOperationType is emitted by Gradle.
+ * We want to check the output of the build but as well the correct behavior of Talaiot with a given Publisher.
+ */
+class BuildCacheRemoteLoadBuildOperationTypeTest : BehaviorSpec() {
+    private val containerRedis = KRedisContainer()
+    private val containerInfluxDb = KInfluxDBContainer().withAuthEnabled(false)
+
+    val influxDB by lazy {
+        containerInfluxDb.newInfluxDB
+    }
+
+    override fun beforeSpec(spec: Spec) {
+        super.beforeSpec(spec)
+        containerRedis.start()
+        containerInfluxDb.start()
+    }
+
+    override fun afterSpec(spec: Spec) {
+        super.afterSpec(spec)
+        containerRedis.stop()
+        containerInfluxDb.stop()
+    }
+
+    init {
+        given("A project with Talaiot and Remote Caching enabled using Redis as Remote Caching") {
+
+            val testProjectDir = TemporaryFolder()
+            testProjectDir.create()
+
+            testProjectDir.newFile("gradle.properties")
+                .appendText(Configuration.gradleProperties)
+
+            testProjectDir.newFile("settings.gradle")
+                .appendText(Configuration.settingsGradle(containerRedis.httpHostAddress))
+
+            testProjectDir.newFile("build.gradle")
+                .appendText(Configuration.buildGradle(containerInfluxDb.url))
+
+            testProjectDir.newFileInPath("src/main/java/A.java")
+                .appendText(Configuration.createFile())
+
+            `when`("there are a sequence of execution for tasks: assemble, clean, assemble again") {
+                val firstAssembleExecution = GradleRunner.create()
+                    .withProjectDir(testProjectDir.getRoot())
+                    .withArguments("assemble")
+                    .withPluginClasspath()
+                    .build()
+
+                val cleanExecution = GradleRunner.create()
+                    .withProjectDir(testProjectDir.getRoot())
+                    .withArguments("clean")
+                    .withPluginClasspath()
+                    .build()
+
+                val secondAssembleExecution = GradleRunner.create()
+                    .withProjectDir(testProjectDir.getRoot())
+                    .withArguments("assemble")
+                    .withPluginClasspath()
+                    .build()
+
+                then("First assemble execution feed the cache and Second assemble execution contains build Info with the task state coming from cache") {
+
+                    // Just assert the output to check the state of the tasks
+                    assertTrue(!firstAssembleExecution.output.contains("FROM-CACHE"))
+                    assertTrue(secondAssembleExecution.output.contains("FROM-CACHE"))
+
+                    // Talaiot was configured with InfluxDb.
+                    // Let's check if the cacheable task exists in the two executions with the different states
+                    // and test the caching properties(remoteCacheHit) have been emitted properly from Gradle
+                    val taskResultTask =
+                        influxDB.query(Query("select * from tracking.rpTalaiot.task where task=':compileJava'"))
+
+                    val firstExecution =
+                        taskResultTask.results.joinToString { it.series.joinToString { it.values[0].joinToString() } }
+                    val secondExecution =
+                        taskResultTask.results.joinToString { it.series.joinToString { it.values[1].joinToString() } }
+
+                    assert(taskResultTask.results[0].series[0].values.size == 2)
+                    assert(firstExecution.contains("EXECUTED"))
+                    assert(secondExecution.contains("FROM_CACHE"))
+
+                    val remoteCacheHit =
+                        influxDB.query(Query("select * from tracking.rpTalaiot.task where remoteCacheHit='true'"))
+
+                    assert(remoteCacheHit.results[0].series[0].values.size == 1)
+
+                }
+                testProjectDir.delete()
+            }
+        }
+    }
+
+}
+
+object Configuration {
+    val gradleProperties = "org.gradle.caching=true"
+    fun settingsGradle(containerUrl: String) = """
+        buildscript {
+            repositories {
+                mavenLocal()
+                maven {
+                    url 'https://plugins.gradle.org/m2/'
+                }
+            }
+
+            dependencies {
+                classpath 'gradle.plugin.net.idlestate:gradle-redis-build-cache:1.2.1'
+            }
+        }
+
+        buildCache {
+            local {
+                enabled = false
+            }
+            registerBuildCacheService(net.idlestate.gradle.caching.RedisBuildCache.class,
+                    net.idlestate.gradle.caching.RedisBuildCacheServiceFactory.class)
+
+            remote( net.idlestate.gradle.caching.RedisBuildCache.class ) {
+                host = 'localhost'
+                port = ${containerUrl.split(":")[1]}
+                enabled = true
+                push = true
+            }
+        }
+        
+    """.trimIndent()
+
+    fun buildGradle(containerUrl: String) = """
+        plugins {
+            id 'java'
+            id 'com.cdsap.talaiot'
+        }
+                 
+        talaiot{
+            publishers {
+                logger = com.cdsap.talaiot.logger.LogTracker.Mode.INFO                      
+                influxDbPublisher { 
+                    dbName = "tracking"
+                    url = "$containerUrl"
+                    taskMetricName = "task"
+                    buildMetricName = "build"
+                }
+            }
+        }        
+    """.trimIndent()
+
+    fun createFile() = """
+        class A {
+            public A(){
+            }
+        }
+    """.trimIndent()
+}

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/e2e/TemporaryFolder.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/e2e/TemporaryFolder.kt
@@ -23,6 +23,13 @@ class TemporaryFolder {
         return file
     }
 
+    fun newFileInPath(fileName: String): File {
+        val file = File(getRoot(), fileName).also { file ->
+            file.parentFile.mkdirs()
+        }
+        return file
+    }
+
     @Throws(IOException::class)
     fun newFile(): File {
         return File.createTempFile("junit", null, getRoot())

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/publisher/KRedisContainer.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/publisher/KRedisContainer.kt
@@ -1,0 +1,5 @@
+package com.cdsap.talaiot.publisher
+
+import org.testcontainers.remotecache.RedisRemoteCacheContainer
+
+class KRedisContainer : RedisRemoteCacheContainer()

--- a/talaiot/src/test/kotlin/org/testcontainers/remotecache/RedisRemoteCacheContainer.kt
+++ b/talaiot/src/test/kotlin/org/testcontainers/remotecache/RedisRemoteCacheContainer.kt
@@ -1,0 +1,53 @@
+package org.testcontainers.remotecache
+
+import org.testcontainers.utility.Base58
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy
+
+import java.net.InetSocketAddress
+
+/**
+ * Custom TestContainer to support E2E tests for Redis
+ */
+open class RedisRemoteCacheContainer :
+    GenericContainer<RedisRemoteCacheContainer>("$REDIS_IMAGE:$REDIS_DEFAULT_VERSION") {
+    init {
+
+        logger().info("Starting an Redis container using [{}]", dockerImageName)
+        withNetworkAliases("redis-" + Base58.randomString(6))
+        withEnv("discovery.type", "single-node")
+        addExposedPorts(REDIS_DEFAULT_PORT, REDIS_DEFAULT_TCP_PORT)
+        setWaitStrategy(
+            WaitAllStrategy()
+                .withStrategy(
+                    Wait.forListeningPort()
+                )
+        )
+    }
+
+    val httpHostAddress: String
+        get() = containerIpAddress + ":" + getMappedPort(REDIS_DEFAULT_PORT)
+
+    fun getTcpHost(): InetSocketAddress {
+        return InetSocketAddress(containerIpAddress, getMappedPort(REDIS_DEFAULT_TCP_PORT)!!)
+    }
+
+    companion object {
+
+        /**
+         * Redis Default HTTP port
+         */
+        private val REDIS_DEFAULT_PORT = 6379
+
+        /**
+         * Redis Docker base URL
+         */
+        private val REDIS_IMAGE = "redis"
+        private val REDIS_DEFAULT_TCP_PORT = 6379
+        /**
+         * Redis Default version
+         */
+        protected val REDIS_DEFAULT_VERSION = "latest"
+    }
+}


### PR DESCRIPTION
New test to cover if the event BuildCacheRemoteLoadBuildOperationType is emitted by Gradle.
We use `testKit` from Gradle to create a project with:

- Gradle Properties enabling cache
- Settings Gradle adding one Remote Cache Service to store the results of the cache
- Build Gradle, using Talaiot with `InfluxDbPublisher`

Once we have the project we need to execute a sequence of commands to reproduce the scenario where we push to the cache, then we clean, and we build again hitting the cache. 
With  this behavior we can test the Gradle Caching Task operation:
- Testing the output of the build
- Testing the State of the task and operation type in a InfluxDb populated previously by Talaiot.

Includes a new Test Container for Redis.

This PR closes #171.
