### PR TITLE
Allow more than one custom Publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,8 +335,20 @@ Talaiot will send to the RethinkDb server defined in the configuration the value
 
 
 #### Custom Publishers
-Talaiot allows using custom Publishers defined by the requirements of your environment, in case you are using another implementation.
-Check [here](https://github.com/cdsap/Talaiot/wiki/Publishers#custompublisher) how to define a custom publisher
+Talaiot allows using custom publishers defined by the requirements of your environment, in case you are using another implementation.
+
+```
+talaiot {
+    publishers {
+        // You can define one or more custom publishers:
+        customPublishers(
+            MyCustomPublisher()
+        )
+    }
+}
+```
+
+Read more about it in the [Publishers wiki page](https://github.com/cdsap/Talaiot/wiki/Publishers#custompublishers)
 
 ### Metrics
 We can include extra information on the build and task tracked data during the build. This information will be added to the default metrics defined.

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -23,23 +23,35 @@ dependencies {
 talaiot {
     logger = LogTracker.Mode.INFO
     publishers {
+        // Publishers that don't require a configuration can be enabled or disabled with a flag.
+        // By default all publishers are disabled.
         timelinePublisher = true
+        jsonPublisher = false
+
+        // Talaiot provides a few pre-defined publishers.
+        // Declaring a configuration for any of those publishers will enable them.
         taskDependencyGraphPublisher {
             html = true
             gexf = true
         }
+
         influxDbPublisher {
             dbName = "tracking"
             url = "http://localhost:8086"
             taskMetricName = "task"
             buildMetricName = "build"
         }
-        customPublisher = CustomPublisher()
+
+        // You can also define your own custom publishers:
+        customPublishers(
+            CustomPublisher(),
+            HelloPublisher()
+        )
     }
 
     metrics {
-        // Talaiot provides a few methods to disable a group of metrics at once
-        // By default all groups are enabled
+        // Talaiot provides a few methods to disable a group of metrics at once.
+        // By default all groups are enabled.
         performanceMetrics = false
         gradleSwitchesMetrics = false
         environmentMetrics = false
@@ -65,10 +77,15 @@ talaiot {
 class CustomPublisher : Publisher {
     override fun publish(report: ExecutionReport) {
         println("[CustomPublisher] : Number of tasks = ${report.tasks?.size}")
-        println("[CustomPublisher] : HelloMetric = ${report.customProperties.buildProperties["hello"]}")
         println("[CustomPublisher] : Kotlin = ${report.customProperties.buildProperties["kotlin"]}")
         println("[CustomPublisher] : Java = ${report.customProperties.buildProperties["java"]}")
         println("[CustomPublisher] : PID = ${report.customProperties.taskProperties["pid"]}")
+    }
+}
+
+class HelloPublisher : Publisher {
+    override fun publish(report: ExecutionReport) {
+        println("[HelloPublisher] : HelloMetric = ${report.customProperties.buildProperties["hello"]}")
     }
 }
 

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/PublishersConfiguration.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/PublishersConfiguration.kt
@@ -1,15 +1,19 @@
 package com.cdsap.talaiot.configuration
 
-import com.cdsap.talaiot.publisher.Publisher
+import com.cdsap.talaiot.publisher.*
+import com.cdsap.talaiot.publisher.pushgateway.PushGatewayPublisher
 import com.cdsap.talaiot.publisher.rethinkdb.RethinkDbPublisher
+import com.cdsap.talaiot.publisher.timeline.TimelinePublisher
 import groovy.lang.Closure
 import org.gradle.api.Project
+
 
 /**
  * Main configuration for the publishers.
  *
  * It offers the accessors for Groovy and KTS
  *
+ * ```
  * publishers {
  *    influxDbPublisher {
  *    }
@@ -22,6 +26,7 @@ import org.gradle.api.Project
  *    customDependencies {
  *    }
  * }
+ * ```
  */
 class PublishersConfiguration(
     val project: Project
@@ -37,47 +42,17 @@ class PublishersConfiguration(
     internal var customPublishers: MutableSet<Publisher> = mutableSetOf()
 
     /**
-     * Flag to enable [com.cdsap.talaiot.publisher.timeline.TimelinePublisher]
-     *
-     * Generates an html report with the timeline of task execution
+     * Enables a [TimelinePublisher] if set to `true`. Disabled by default.
      */
     var timelinePublisher: Boolean = false
+
     /**
-     * Flag to enable [com.cdsap.talaiot.publisher.JsonPublisher]
-     *
-     * Generates a json representation of [com.cdsap.talaiot.entities.ExecutionReport]
+     * Enables a [JsonPublisher] if set to `true`. Disabled by default.
      */
     var jsonPublisher: Boolean = false
 
     /**
-     * Configuration accessor within the [PublishersConfiguration] for the [com.cdsap.talaiot.publisher.TaskDependencyGraphPublisher]
-     *
-     * @param configuration Configuration block for the [TaskDependencyGraphConfiguration]
-     */
-    fun taskDependencyGraphPublisher(configuration: TaskDependencyGraphConfiguration.() -> Unit) {
-        taskDependencyGraphPublisher = TaskDependencyGraphConfiguration(project).also(configuration)
-    }
-
-    /**
-     * Configuration accessor within the [PublishersConfiguration] for the [com.cdsap.talaiot.publisher.InfluxDbPublisher]
-     *
-     * @param configuration Configuration block for the [InfluxDbPublisherConfiguration]
-     */
-    fun influxDbPublisher(configuration: InfluxDbPublisherConfiguration.() -> Unit) {
-        influxDbPublisher = InfluxDbPublisherConfiguration().also(configuration)
-    }
-
-    /**
-     * Configuration accessor within the [PublishersConfiguration] for the [com.cdsap.talaiot.publisher.PushGatewayPublisher]
-     *
-     * @param configuration Configuration block for the [PushGatewayPublisherConfiguration]
-     */
-    fun pushGatewayPublisher(configuration: PushGatewayPublisherConfiguration.() -> Unit) {
-        pushGatewayPublisher = PushGatewayPublisherConfiguration().also(configuration)
-    }
-
-    /**
-     * Configuration accessor within the [PublishersConfiguration] for the [com.cdsap.talaiot.publisher.ElasticSearchPublisher]
+     * Configuration accessor within the [PublishersConfiguration] for the [ElasticSearchPublisher]
      *
      * @param configuration Configuration block for the [ElasticSearchPublisherConfiguration]
      */
@@ -86,7 +61,18 @@ class PublishersConfiguration(
     }
 
     /**
-     * Configuration accessor within the [PublishersConfiguration] for the [com.cdsap.talaiot.publisher.HybridPublisher]
+     * Configuration accessor within the [PublishersConfiguration] for the [ElasticSearchPublisher]
+     *
+     * @param closure closure for the [ElasticSearchPublisherConfiguration]
+     */
+    fun elasticSearchPublisher(closure: Closure<*>) {
+        elasticSearchPublisher = ElasticSearchPublisherConfiguration()
+        closure.delegate = elasticSearchPublisher
+        closure.call()
+    }
+
+    /**
+     * Configuration accessor within the [PublishersConfiguration] for the [HybridPublisher]
      *
      * @param configuration Configuration block for the [HybridPublisherConfiguration]
      */
@@ -95,7 +81,38 @@ class PublishersConfiguration(
     }
 
     /**
-     * Configuration accessor within the [PublishersConfiguration] for the [com.cdsap.talaiot.publisher.OutputPublisher]
+     * Configuration accessor within the [HybridPublisherConfiguration] for the [HybridPublisher]
+     *
+     * @param closure closure for the [HybridPublisherConfiguration]
+     */
+    fun hybridPublisher(closure: Closure<*>) {
+        hybridPublisher = HybridPublisherConfiguration()
+        closure.delegate = hybridPublisher
+        closure.call()
+    }
+
+    /**
+     * Configuration accessor within the [PublishersConfiguration] for the [InfluxDbPublisher]
+     *
+     * @param configuration Configuration block for the [InfluxDbPublisherConfiguration]
+     */
+    fun influxDbPublisher(configuration: InfluxDbPublisherConfiguration.() -> Unit) {
+        influxDbPublisher = InfluxDbPublisherConfiguration().also(configuration)
+    }
+
+    /**
+     * Configuration accessor within the [PublishersConfiguration] for the [InfluxDbPublisher]
+     *
+     * @param closure closure for the [InfluxDbPublisherConfiguration]
+     */
+    fun influxDbPublisher(closure: Closure<*>) {
+        influxDbPublisher = InfluxDbPublisherConfiguration()
+        closure.delegate = influxDbPublisher
+        closure.call()
+    }
+
+    /**
+     * Configuration accessor within the [PublishersConfiguration] for the [OutputPublisher]
      *
      * @param configuration Configuration block for the [OutputPublisherConfiguration]
      */
@@ -104,12 +121,34 @@ class PublishersConfiguration(
     }
 
     /**
-     * Adds the given custom publishers into the publisher list.
+     * Configuration accessor within the [PublishersConfiguration] for the [OutputPublisher]
      *
-     * @param publishers takes N [Publisher]s to be added to the publishers list.
+     * @param closure closure for the [OutputPublisherConfiguration]
      */
-    fun customPublishers(vararg publishers: Publisher) {
-        customPublishers.addAll(publishers)
+    fun outputPublisher(closure: Closure<*>) {
+        outputPublisher = OutputPublisherConfiguration()
+        closure.delegate = outputPublisher
+        closure.call()
+    }
+
+    /**
+     * Configuration accessor within the [PublishersConfiguration] for the [PushGatewayPublisher]
+     *
+     * @param configuration Configuration block for the [PushGatewayPublisherConfiguration]
+     */
+    fun pushGatewayPublisher(configuration: PushGatewayPublisherConfiguration.() -> Unit) {
+        pushGatewayPublisher = PushGatewayPublisherConfiguration().also(configuration)
+    }
+
+    /**
+     * Configuration accessor within the [PublishersConfiguration] for the [PushGatewayPublisher]
+     *
+     * @param closure closure for the [PushGatewayPublisherConfiguration]
+     */
+    fun pushGatewayPublisher(closure: Closure<*>) {
+        pushGatewayPublisher = PushGatewayPublisherConfiguration()
+        closure.delegate = pushGatewayPublisher
+        closure.call()
     }
 
     /**
@@ -122,18 +161,26 @@ class PublishersConfiguration(
     }
 
     /**
-     * Configuration accessor within the [PublishersConfiguration] for the [com.cdsap.talaiot.publisher.InfluxDbPublisher]
+     * Configuration accessor within the [RethinkDbPublisherConfiguration] for the [RethinkDbPublisher]
      *
-     * @param closure closure for the [InfluxDbPublisherConfiguration]
+     * @param closure closure for the [RethinkDbPublisherConfiguration]
      */
-    fun influxDbPublisher(closure: Closure<*>) {
-        influxDbPublisher = InfluxDbPublisherConfiguration()
-        closure.delegate = influxDbPublisher
+    fun rethinkDbPublisher(closure: Closure<*>) {
+        rethinkDbPublisher = RethinkDbPublisherConfiguration()
+        closure.delegate = rethinkDbPublisher
         closure.call()
+    }
+    /**
+     * Configuration accessor within the [PublishersConfiguration] for the [TaskDependencyGraphPublisher]
+     *
+     * @param configuration Configuration block for the [TaskDependencyGraphConfiguration]
+     */
+    fun taskDependencyGraphPublisher(configuration: TaskDependencyGraphConfiguration.() -> Unit) {
+        taskDependencyGraphPublisher = TaskDependencyGraphConfiguration(project).also(configuration)
     }
 
     /**
-     * Configuration accessor within the [PublishersConfiguration] for the [com.cdsap.talaiot.publisher.TaskDependencyGraphPublisher]
+     * Configuration accessor within the [PublishersConfiguration] for the [TaskDependencyGraphPublisher]
      *
      * @param closure closure for the [TaskDependencyGraphConfiguration]
      */
@@ -144,57 +191,11 @@ class PublishersConfiguration(
     }
 
     /**
-     * Configuration accessor within the [PublishersConfiguration] for the [com.cdsap.talaiot.publisher.ElasticSearchPublisher]
+     * Adds the given custom publishers into the publisher list.
      *
-     * @param closure closure for the [ElasticSearchPublisherConfiguration]
+     * @param publishers takes N [Publisher]s to be added to the publishers list.
      */
-    fun elasticSearchPublisher(closure: Closure<*>) {
-        elasticSearchPublisher = ElasticSearchPublisherConfiguration()
-        closure.delegate = elasticSearchPublisher
-        closure.call()
-    }
-
-    /**
-     * Configuration accessor within the [HybridPublisherConfiguration] for the [com.cdsap.talaiot.publisher.HybridPublisher]
-     *
-     * @param closure closure for the [HybridPublisherConfiguration]
-     */
-    fun hybridPublisher(closure: Closure<*>) {
-        hybridPublisher = HybridPublisherConfiguration()
-        closure.delegate = hybridPublisher
-        closure.call()
-    }
-
-    /**
-     * Configuration accessor within the [PublishersConfiguration] for the [com.cdsap.talaiot.publisher.OutputPublisher]
-     *
-     * @param closure closure for the [OutputPublisherConfiguration]
-     */
-    fun outputPublisher(closure: Closure<*>) {
-        outputPublisher = OutputPublisherConfiguration()
-        closure.delegate = outputPublisher
-        closure.call()
-    }
-
-    /**
-     * Configuration accessor within the [PublishersConfiguration] for the [com.cdsap.talaiot.publisher.PushGatewayPublisher]
-     *
-     * @param closure closure for the [PushGatewayPublisherConfiguration]
-     */
-    fun pushGatewayPublisher(closure: Closure<*>) {
-        pushGatewayPublisher = PushGatewayPublisherConfiguration()
-        closure.delegate = pushGatewayPublisher
-        closure.call()
-    }
-
-    /**
-     * Configuration accessor within the [RethinkDbPublisherConfiguration] for the [com.cdsap.talaiot.publisher.RethinkDbPublisher]
-     *
-     * @param closure closure for the [RethinkDbPublisherConfiguration]
-     */
-    fun rethinkDbPublisher(closure: Closure<*>) {
-        rethinkDbPublisher = RethinkDbPublisherConfiguration()
-        closure.delegate = rethinkDbPublisher
-        closure.call()
+    fun customPublishers(vararg publishers: Publisher) {
+        customPublishers.addAll(publishers)
     }
 }

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/PublishersConfiguration.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/PublishersConfiguration.kt
@@ -26,22 +26,16 @@ import org.gradle.api.Project
 class PublishersConfiguration(
     val project: Project
 ) {
-    /**
-     * Access to the configuration of [com.cdsap.talaiot.publisher.InfluxDbPublisher]
-     */
+    internal var elasticSearchPublisher: ElasticSearchPublisherConfiguration? = null
+    internal var hybridPublisher: HybridPublisherConfiguration? = null
     internal var influxDbPublisher: InfluxDbPublisherConfiguration? = null
-    /**
-     * Access to the configuration of [com.cdsap.talaiot.publisher.OutputPublisher]
-     */
     internal var outputPublisher: OutputPublisherConfiguration? = null
-    /**
-     * Access to the configuration of [com.cdsap.talaiot.publisher.PushGatewayPublisher]
-     */
     internal var pushGatewayPublisher: PushGatewayPublisherConfiguration? = null
-    /**
-     * Access to the configuration of [com.cdsap.talaiot.publisher.TaskDependencyGraphPublisher]
-     */
+    internal var rethinkDbPublisher: RethinkDbPublisherConfiguration? = null
     internal var taskDependencyGraphPublisher: TaskDependencyGraphConfiguration? = null
+
+    internal var customPublisher: Publisher? = null
+
     /**
      * Flag to enable [com.cdsap.talaiot.publisher.timeline.TimelinePublisher]
      *
@@ -54,24 +48,6 @@ class PublishersConfiguration(
      * Generates a json representation of [com.cdsap.talaiot.entities.ExecutionReport]
      */
     var jsonPublisher: Boolean = false
-    /**
-     * Access to the configuration of [com.cdsap.talaiot.publisher.ElasticSearchPublisher]
-     */
-    internal var elasticSearchPublisher: ElasticSearchPublisherConfiguration? = null
-    /**
-     * Access to the configuration of [com.cdsap.talaiot.publisher.HybridPublisher]
-     */
-    internal var hybridPublisher: HybridPublisherConfiguration? = null
-    /**
-     * Access to the configuration of [com.cdsap.talaiot.publisher.RethinkDbPublisher]
-     */
-    internal var rethinkDbPublisher: RethinkDbPublisherConfiguration? = null
-    /**
-     * Definition of a custom Publisher in the PublisherConfiguration. Requires implementation of Publisher.
-     *
-     * Some users of plugin might need to use a custom publisher to push to internal analytics for example.
-     */
-    internal var customPublisher: Publisher? = null
 
     /**
      * Configuration accessor within the [PublishersConfiguration] for the [com.cdsap.talaiot.publisher.TaskDependencyGraphPublisher]

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/PublishersConfiguration.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/PublishersConfiguration.kt
@@ -34,7 +34,7 @@ class PublishersConfiguration(
     internal var rethinkDbPublisher: RethinkDbPublisherConfiguration? = null
     internal var taskDependencyGraphPublisher: TaskDependencyGraphConfiguration? = null
 
-    internal var customPublisher: Publisher? = null
+    internal var customPublishers: MutableSet<Publisher> = mutableSetOf()
 
     /**
      * Flag to enable [com.cdsap.talaiot.publisher.timeline.TimelinePublisher]
@@ -104,14 +104,12 @@ class PublishersConfiguration(
     }
 
     /**
-     * Configuration accessor within the [PublishersConfiguration] for the custom implementation for [Publisher]
+     * Adds the given custom publishers into the publisher list.
      *
-     * Will override another custom publisher instance if present
-     *
-     * @param configuration instance of your publisher
+     * @param publishers takes N [Publisher]s to be added to the publishers list.
      */
-    fun customPublisher(configuration: Publisher) {
-        customPublisher = configuration
+    fun customPublishers(vararg publishers: Publisher) {
+        customPublishers.addAll(publishers)
     }
 
     /**

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/PublishersConfiguration.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/PublishersConfiguration.kt
@@ -1,6 +1,5 @@
 package com.cdsap.talaiot.configuration
 
-
 import com.cdsap.talaiot.publisher.Publisher
 import com.cdsap.talaiot.publisher.rethinkdb.RethinkDbPublisher
 import groovy.lang.Closure
@@ -30,19 +29,19 @@ class PublishersConfiguration(
     /**
      * Access to the configuration of [com.cdsap.talaiot.publisher.InfluxDbPublisher]
      */
-    var influxDbPublisher: InfluxDbPublisherConfiguration? = null
+    internal var influxDbPublisher: InfluxDbPublisherConfiguration? = null
     /**
      * Access to the configuration of [com.cdsap.talaiot.publisher.OutputPublisher]
      */
-    var outputPublisher: OutputPublisherConfiguration? = null
+    internal var outputPublisher: OutputPublisherConfiguration? = null
     /**
      * Access to the configuration of [com.cdsap.talaiot.publisher.PushGatewayPublisher]
      */
-    var pushGatewayPublisher: PushGatewayPublisherConfiguration? = null
+    internal var pushGatewayPublisher: PushGatewayPublisherConfiguration? = null
     /**
      * Access to the configuration of [com.cdsap.talaiot.publisher.TaskDependencyGraphPublisher]
      */
-    var taskDependencyGraphPublisher: TaskDependencyGraphConfiguration? = null
+    internal var taskDependencyGraphPublisher: TaskDependencyGraphConfiguration? = null
     /**
      * Flag to enable [com.cdsap.talaiot.publisher.timeline.TimelinePublisher]
      *
@@ -58,24 +57,21 @@ class PublishersConfiguration(
     /**
      * Access to the configuration of [com.cdsap.talaiot.publisher.ElasticSearchPublisher]
      */
-
-    var elasticSearchPublisher: ElasticSearchPublisherConfiguration? = null
+    internal var elasticSearchPublisher: ElasticSearchPublisherConfiguration? = null
     /**
      * Access to the configuration of [com.cdsap.talaiot.publisher.HybridPublisher]
      */
-
-    var hybridPublisher: HybridPublisherConfiguration? = null
+    internal var hybridPublisher: HybridPublisherConfiguration? = null
     /**
      * Access to the configuration of [com.cdsap.talaiot.publisher.RethinkDbPublisher]
      */
-    var rethinkDbPublisher: RethinkDbPublisherConfiguration? = null
-
+    internal var rethinkDbPublisher: RethinkDbPublisherConfiguration? = null
     /**
      * Definition of a custom Publisher in the PublisherConfiguration. Requires implementation of Publisher.
      *
      * Some users of plugin might need to use a custom publisher to push to internal analytics for example.
      */
-    var customPublisher: Publisher? = null
+    internal var customPublisher: Publisher? = null
 
     /**
      * Configuration accessor within the [PublishersConfiguration] for the [com.cdsap.talaiot.publisher.TaskDependencyGraphPublisher]
@@ -227,5 +223,4 @@ class PublishersConfiguration(
         closure.delegate = rethinkDbPublisher
         closure.call()
     }
-
 }

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/provider/PublishersProvider.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/provider/PublishersProvider.kt
@@ -2,6 +2,7 @@ package com.cdsap.talaiot.provider
 
 import com.cdsap.talaiot.TalaiotExtension
 import com.cdsap.talaiot.logger.LogTracker
+import com.cdsap.talaiot.configuration.PublishersConfiguration
 import com.cdsap.talaiot.publisher.*
 import com.cdsap.talaiot.publisher.graphpublisher.GraphPublisherFactoryImpl
 import com.cdsap.talaiot.publisher.pushgateway.PushGatewayFormatter
@@ -11,10 +12,9 @@ import com.cdsap.talaiot.publisher.timeline.TimelinePublisher
 import com.cdsap.talaiot.request.SimpleRequest
 import org.gradle.api.Project
 import java.util.concurrent.Executor
-import java.util.concurrent.Executors
 
 /**
- * Provides the [Publisher]s defined in the [com.cdsap.talaiot.configuration.PublishersConfiguration] of the [TalaiotExtension]
+ * Provides the [Publisher]s defined in the [PublishersConfiguration] of the [TalaiotExtension]
  */
 class PublishersProvider(
     /**
@@ -37,8 +37,6 @@ class PublishersProvider(
         val talaiotExtension = project.extensions.getByName("talaiot") as TalaiotExtension
 
         talaiotExtension.publishers?.apply {
-
-
             outputPublisher?.apply {
                 publishers.add(OutputPublisher(this, logger))
             }
@@ -111,9 +109,7 @@ class PublishersProvider(
                 )
             }
 
-            customPublisher?.apply {
-                publishers.add(this)
-            }
+            publishers.addAll(customPublishers)
         }
         return publishers
     }

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/e2e/IntegrationSpec.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/e2e/IntegrationSpec.kt
@@ -42,7 +42,7 @@ class DefaultConfigurationSpec : StringSpec({
                     logger = com.cdsap.talaiot.logger.LogTracker.Mode.INFO
                     publishers {
                         jsonPublisher = true
-                        customPublisher = new JsonPublisher(getGradle())
+                        customPublishers(new JsonPublisher(getGradle()))
                     }
                 }
 

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/mock/CustomPublishersMock.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/mock/CustomPublishersMock.kt
@@ -1,0 +1,8 @@
+package com.cdsap.talaiot.mock
+
+import com.cdsap.talaiot.entities.ExecutionReport
+import com.cdsap.talaiot.publisher.Publisher
+
+class TestPublisher : Publisher {
+    override fun publish(report: ExecutionReport) {}
+}

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/mock/CustomPublishersMock.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/mock/CustomPublishersMock.kt
@@ -6,3 +6,7 @@ import com.cdsap.talaiot.publisher.Publisher
 class TestPublisher : Publisher {
     override fun publish(report: ExecutionReport) {}
 }
+
+class ConsolePublisher : Publisher {
+    override fun publish(report: ExecutionReport) {}
+}

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/publisher/PublishersProviderTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/publisher/PublishersProviderTest.kt
@@ -4,6 +4,7 @@ import com.cdsap.talaiot.TalaiotExtension
 import com.cdsap.talaiot.entities.ExecutionReport
 import com.cdsap.talaiot.logger.LogTracker
 import com.cdsap.talaiot.logger.LogTrackerImpl
+import com.cdsap.talaiot.mock.TestPublisher
 import com.cdsap.talaiot.provider.PublishersProvider
 import com.cdsap.talaiot.publisher.rethinkdb.RethinkDbPublisher
 import io.kotlintest.inspectors.forAll
@@ -75,7 +76,7 @@ class PublishersProviderTest : BehaviorSpec({
                 customPublishers(TestPublisher())
             }
             val publishers = PublishersProvider(project, logger, TestExecutor(), TestExecutor()).get()
-            then("instance of CustomPublisher is created") {
+            then("instance of TestPublisher exists") {
                 publishers.forAtLeastOne {
                     it is TestPublisher
                 }
@@ -125,7 +126,3 @@ class PublishersProviderTest : BehaviorSpec({
         }
     }
 })
-
-class TestPublisher : Publisher {
-    override fun publish(report: ExecutionReport) {}
-}

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/publisher/PublishersProviderTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/publisher/PublishersProviderTest.kt
@@ -11,7 +11,6 @@ import io.kotlintest.inspectors.forAtLeastOne
 import io.kotlintest.specs.BehaviorSpec
 import org.gradle.testfixtures.ProjectBuilder
 
-
 class PublishersProviderTest : BehaviorSpec({
     given("Publisher Provider") {
         val logger = LogTrackerImpl(LogTracker.Mode.SILENT)
@@ -69,11 +68,11 @@ class PublishersProviderTest : BehaviorSpec({
                 }
             }
         }
-        `when`("CustomPublisher is included") {
+        `when`("One custom publisher is included") {
             val project = ProjectBuilder.builder().build()
             val talaiotExtension = project.extensions.create("talaiot", TalaiotExtension::class.java, project)
             talaiotExtension.publishers {
-                customPublisher(TestPublisher())
+                customPublishers(TestPublisher())
             }
             val publishers = PublishersProvider(project, logger, TestExecutor(), TestExecutor()).get()
             then("instance of CustomPublisher is created") {
@@ -87,7 +86,7 @@ class PublishersProviderTest : BehaviorSpec({
             val talaiotExtension = project.extensions.create("talaiot", TalaiotExtension::class.java, project)
             talaiotExtension.publishers {
                 rethinkDbPublisher {
-                 buildTableName = "builds"
+                    buildTableName = "builds"
                 }
             }
             val publishers = PublishersProvider(project, logger, TestExecutor(), TestExecutor()).get()
@@ -102,7 +101,7 @@ class PublishersProviderTest : BehaviorSpec({
             val project = ProjectBuilder.builder().build()
             val talaiotExtension = project.extensions.create("talaiot", TalaiotExtension::class.java, project)
             talaiotExtension.publishers {
-                customPublisher(TestPublisher())
+                customPublishers(TestPublisher())
                 taskDependencyGraphPublisher {
                     gexf = true
                 }
@@ -128,8 +127,5 @@ class PublishersProviderTest : BehaviorSpec({
 })
 
 class TestPublisher : Publisher {
-    override fun publish(report: ExecutionReport) {
-
-    }
-
+    override fun publish(report: ExecutionReport) {}
 }

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/publisher/PublishersProviderTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/publisher/PublishersProviderTest.kt
@@ -1,9 +1,9 @@
 package com.cdsap.talaiot.publisher
 
 import com.cdsap.talaiot.TalaiotExtension
-import com.cdsap.talaiot.entities.ExecutionReport
 import com.cdsap.talaiot.logger.LogTracker
 import com.cdsap.talaiot.logger.LogTrackerImpl
+import com.cdsap.talaiot.mock.ConsolePublisher
 import com.cdsap.talaiot.mock.TestPublisher
 import com.cdsap.talaiot.provider.PublishersProvider
 import com.cdsap.talaiot.publisher.rethinkdb.RethinkDbPublisher
@@ -79,6 +79,23 @@ class PublishersProviderTest : BehaviorSpec({
             then("instance of TestPublisher exists") {
                 publishers.forAtLeastOne {
                     it is TestPublisher
+                }
+            }
+        }
+        `when`("Two custom publishers are included") {
+            val project = ProjectBuilder.builder().build()
+            val talaiotExtension = project.extensions.create("talaiot", TalaiotExtension::class.java, project)
+            talaiotExtension.publishers {
+                customPublishers(
+                    TestPublisher(),
+                    ConsolePublisher()
+                )
+            }
+            val publishers = PublishersProvider(project, logger, TestExecutor(), TestExecutor()).get()
+            then("instance of TestPublisher and ConsolePublisher exists") {
+                publishers.forAll {
+                    it is TestPublisher
+                    it is ConsolePublisher
                 }
             }
         }


### PR DESCRIPTION
### Summary

This PR proposes an update to support one or more custom `Publisher`s in the `PublishersConfiguration`.
It solves #170.

This update will bring the the `publisher` DSL closer to the [new `metrics` DSL](https://github.com/cdsap/Talaiot/pull/162).

### Notable changes

#### Changes to DSL

Assigning a single publisher is not supported anymore:

```
publishers {
    customPublisher = CustomPublisher()
}
```

The new syntax requires a call to `customPublishers`, passing one or more publishers:

```
publishers {
    customPublishers(
        MyCustomPublisher(),
        ConsolePublisher()
    )
}
```

#### Changes in behaviour

There should be no changes in the behaviour of how the publishers are executed.

### Configuration example

The DSL has the same syntax in both Kotlin and Groovy.

**Kotlin**

```kotlin
publishers {
    customPublishers(
        MyCustomPublisher()
    )
}
```

**Groovy**

```groovy
publishers {
    customPublishers(
        new MyCustomPublisher()
    )
}
```
