### PR TITLE
Fix: simple custom metrics are not published

### DIFF
--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/MetricsConfiguration.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/configuration/MetricsConfiguration.kt
@@ -290,14 +290,14 @@ class MetricsConfiguration {
     private fun createSimpleBuildMetric(pair: Pair<String, String>): SimpleMetric<String> {
         return SimpleMetric(
             provider = { pair.second },
-            assigner = { report, value -> report.customProperties.buildProperties[pair.second] = value }
+            assigner = { report, value -> report.customProperties.buildProperties[pair.first] = value }
         )
     }
 
     private fun createSimpleTaskMetric(pair: Pair<String, String>): SimpleMetric<String> {
         return SimpleMetric(
             provider = { pair.second },
-            assigner = { report, value -> report.customProperties.taskProperties[pair.second] = value }
+            assigner = { report, value -> report.customProperties.taskProperties[pair.first] = value }
         )
     }
 }


### PR DESCRIPTION
Release 1.3.0 introduced a regression. When simple custom metrics are configured as
```Groovy
  customBuildMetrics(
    "keyA": "valueA"
  )
  customTaskMetrics(
    "keyB": "valueB"
  )
```
resulting the report contains
```json
  "customProperties": {
    "buildProperties": {
      "valueA": "valueA"
    },
    "taskProperties": {
      "valueB": "valueB"
    }
  }
```
while the report should contain
```json
  "customProperties": {
    "buildProperties": {
      "keyA": "valueA"
    },
    "taskProperties": {
      "keyB": "valueB"
    }
  }
```