### PR TITLE
Bump new version after release

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ https://en.wikipedia.org/wiki/Talaiot
 Using the plugins DSL
 ```
 plugins {
-  id("com.cdsap.talaiot") version "1.3.0"
+  id("com.cdsap.talaiot") version "1.3.1"
 }
 ```
 
@@ -54,7 +54,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath("com.cdsap:talaiot:1.3.0")
+    classpath("com.cdsap:talaiot:1.3.1")
   }
 }
 
@@ -65,7 +65,7 @@ apply(plugin = "com.cdsap.talaiot")
 Using the plugins DSL:
 ```
 plugins {
-  id "com.cdsap.talaiot" version "1.3.0"
+  id "com.cdsap.talaiot" version "1.3.1"
 }
 
 ```
@@ -79,7 +79,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "com.cdsap:talaiot:1.3.0"
+    classpath "com.cdsap:talaiot:1.3.1"
   }
 }
 
@@ -96,7 +96,7 @@ maven ( url = uri("http://oss.jfrog.org/artifactory/oss-snapshot-local") )
 And the current Snapshot:
 
 ````
-classpath("com.cdsap:talaiot:1.3.1-SNAPSHOT")
+classpath("com.cdsap:talaiot:1.3.2-SNAPSHOT")
 ````
 
 ## Basic configuration  <a name="basic-configuration"></a>

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 
 plugins {
     kotlin("jvm") version "1.3.60"
-    id("com.cdsap.talaiot") version "1.3.1-SNAPSHOT"
+    id("com.cdsap.talaiot") version "1.3.2-SNAPSHOT"
 }
 
 dependencies {

--- a/talaiot/build.gradle.kts
+++ b/talaiot/build.gradle.kts
@@ -4,14 +4,14 @@ plugins {
     `maven-publish`
     id("jacoco")
     kotlin("jvm") version "1.3.60"
-    id("com.gradle.plugin-publish") version "0.10.0"
+    id("com.gradle.plugin-publish") version "0.12.0"
 }
 
 jacoco {
     toolVersion = "0.8.3"
 }
 
-val versionTalaiot = "1.3.1-SNAPSHOT"
+val versionTalaiot = "1.3.2-SNAPSHOT"
 
 group = "com.cdsap"
 version = versionTalaiot
@@ -49,7 +49,7 @@ pluginBundle {
             displayName = "Talaiot"
             description = "Simple and extensible plugin to track task and build times in your Gradle Project."
             tags = listOf("tracking", "kotlin", "gradle")
-            version = "1.2.0"
+            version = versionTalaiot
         }
     }
 }


### PR DESCRIPTION
1.3.1 has been released:
https://github.com/cdsap/Talaiot/releases/tag/1.3.1

Bumped new version and updated Readme. 

Also updated the Gradle plugin-publish due to:
```
This version of the com.gradle.plugin-publish plugin is no longer supported due to a critical security vulnerability. Please update to the latest version of the com.gradle.plugin-publish plugin found here:
     https://plugins.gradle.org/plugin/com.gradle.plugin-publish 
You can read more about this vulnerability here:
     https://blog.gradle.org/plugin-portal-update
```