### PR TITLE
Keep Double data type for "start" field

### DIFF
--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/metrics/DefaultBuildDataProvider.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/metrics/DefaultBuildDataProvider.kt
@@ -18,7 +18,7 @@ class DefaultBuildMetricsProvider(
             buildInvocationId?.let { map["buildInvocationId"] = it }
             requestedTasks?.let { map["requestedTasks"] = it }
             cacheRatio?.let { map["cacheRatio"] = it.toDouble() }
-            beginMs?.let { map["start"] = it.toLong() }
+            beginMs?.let { map["start"] = it.toDouble() }
             rootProject?.let { map["rootProject"] = it }
             scanLink?.let { map["scanLink"] = it }
 

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/metrics/DefaultBuildDataProviderTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/metrics/DefaultBuildDataProviderTest.kt
@@ -30,10 +30,14 @@ class DefaultBuildMetricsProviderTest : BehaviorSpec({
 
             then("all values are registered") {
                 val expectedMap: Map<String, Any> = mapOf(
+                    "start" to "1.590661991331E12".toDouble(),
                     "duration" to 10L,
                     "configuration" to 32L,
                     "success" to true,
                     "buildId" to "12",
+                    "rootProject" to "app",
+                    "requestedTasks" to "app:assembleDebug",
+                    "scanLink" to "www.scan.link",
                     "buildInvocationId" to "123",
                     "osVersion" to "Linux 1.4",
                     "maxWorkers" to 2.toInt(),

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/report/ExecutionReportProvider.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/report/ExecutionReportProvider.kt
@@ -35,8 +35,13 @@ object ExecutionReportProvider {
     }
 
     fun completeExecutionReport() = ExecutionReport(
+        beginMs = "1.590661991331E12",
+        endMs = "1243",
         durationMs = "10",
         buildId = "12",
+        rootProject = "app",
+        requestedTasks = "app:assembleDebug",
+        scanLink = "www.scan.link",
         buildInvocationId = "123",
         configurationDurationMs = "32",
         environment = Environment(
@@ -72,7 +77,6 @@ object ExecutionReportProvider {
             taskProperties = getMetricsTasks(),
             buildProperties = getMetricsBuild()
         ),
-
         tasks = listOf(
             TaskLength(
                 1, "clean", ":clean", TaskMessageState.EXECUTED, false,


### PR DESCRIPTION
Before https://github.com/cdsap/Talaiot/pull/160 "start" field was exported as Double data type. This PR changes data type back from Long to Double. Otherwise InfluxDB publisher fails with "field type conflict" on existing database.

Add other missing fields from ExecutionReport to the test.

Fixes: https://github.com/cdsap/Talaiot/issues/186