### PR TITLE
Update influxdb-java to 2.19

### DIFF
--- a/talaiot/build.gradle.kts
+++ b/talaiot/build.gradle.kts
@@ -25,7 +25,7 @@ gradlePlugin {
         dependencies {
             implementation("io.github.rybalkinsd:kohttp:0.10.0")
             implementation("guru.nidi:graphviz-java:0.8.3")
-            implementation("org.influxdb:influxdb-java:2.15")
+            implementation("org.influxdb:influxdb-java:2.19")
             implementation("com.github.oshi:oshi-core:3.13.3")
             implementation("com.google.code.gson:gson:2.8.5")
             implementation("org.elasticsearch.client:elasticsearch-rest-high-level-client:7.3.0")

--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/request/SimpleRequest.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/request/SimpleRequest.kt
@@ -30,11 +30,11 @@ class SimpleRequest(mode: LogTracker) : Request {
                     string(content)
                 }
             }.also {
-                logTracker.log(TAG, "Response code ${it.code()}")
+                logTracker.log(TAG, "Response code ${it.code}")
                 if (!it.isSuccessful) {
                     logTracker.log(TAG, "Response code not Successful")
-                    logTracker.log(TAG, "Message Response ${it.message()}")
-                    logTracker.log(TAG, "Response Body ${it.body()?.string()}")
+                    logTracker.log(TAG, "Message Response ${it.message}")
+                    logTracker.log(TAG, "Response Body ${it.body?.string()}")
 
                 }
 

--- a/talaiot/src/test/kotlin/com/cdsap/talaiot/publisher/PushGatewayPublisherTest.kt
+++ b/talaiot/src/test/kotlin/com/cdsap/talaiot/publisher/PushGatewayPublisherTest.kt
@@ -62,7 +62,7 @@ class PushGatewayPublisherTest : BehaviorSpec() {
                             }
                         }
                     }
-                    val content = a.body()?.string()
+                    val content = a.body?.string()
                     assert(
                         content?.contains(":app:assemble{cacheEnabled=\"false\",critical=\"false\",instance=\"\",job=\"task\",localCacheHit=\"false\",localCacheMiss=\"false\",metric1=\"value1\",metric2=\"value2\",module=\"app\",remoteCacheHit=\"false\",remoteCacheMiss=\"false\",rootNode=\"false\",state=\"EXECUTED\",task=\":app:assemble\",value=\"100\",workerId=\"\"} 100")
                             ?: false
@@ -106,7 +106,7 @@ class PushGatewayPublisherTest : BehaviorSpec() {
                             }
                         }
                     }
-                    val content = a.body()?.string()
+                    val content = a.body?.string()
 
                     assert(
                         content?.contains(":app:assemble{cacheEnabled=\"false\",critical=\"false\",instance=\"\",job=\"task2\",localCacheHit=\"false\",localCacheMiss=\"false\",metric1=\"value1\",metric2=\"value2\",module=\"app\",remoteCacheHit=\"false\",remoteCacheMiss=\"false\",rootNode=\"false\",state=\"EXECUTED\",task=\":app:assemble\",value=\"100\",workerId=\"\"} 100")
@@ -152,7 +152,7 @@ class PushGatewayPublisherTest : BehaviorSpec() {
                             }
                         }
                     }
-                    val content = a.body()?.string()
+                    val content = a.body?.string()
 
                     assert(
                         content?.contains("build3")
@@ -191,7 +191,7 @@ class PushGatewayPublisherTest : BehaviorSpec() {
                             }
                         }
                     }
-                    val content = a.body()?.string()
+                    val content = a.body?.string()
 
 
                     content?.contains("metric1=\"value1\",metric2=\"value2\",module=\":test-module\",rootNode=\"false\",state=\"EXECUTED\",task=\":test-module:clean\",value=\"1\",workerId=\"\"} 100")


### PR DESCRIPTION
Release notes: https://github.com/influxdata/influxdb-java/blob/master/CHANGELOG.md

This update brings dependency on okHttp 4.x and with an issue similar to https://github.com/influxdata/influxdb-java/issues/643.
When project includes Talaiot plugin and another plugin that depends on okHttp 4.x, then InfluxDB publishing fails with an error:
>Parameter specified as non-null is null: method okhttp3.Credentials.basic, parameter username