### PR TITLE
Removing BuildCacheOperationListener from buildOperationListenerManager

### DIFF
--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/TalaiotPlugin.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/TalaiotPlugin.kt
@@ -42,7 +42,7 @@ class TalaiotPlugin : Plugin<Project> {
         project.gradle.addBuildListener(listener)
         project.gradle.buildOperationListenerManager().addListener(buildOperationListener)
         project.gradle.buildFinished {
-            project.gradle.removeListener(buildOperationListener)
+            project.gradle.buildOperationListenerManager().removeListener(buildOperationListener)
         }
     }
 


### PR DESCRIPTION
Updated BuildCacheOperationListener remove action to `buildOperationListenerManager`

Heap Dump executing 20 builds of assemble sample project with master:
![Screen Shot 2020-06-30 at 9 51 45 PM](https://user-images.githubusercontent.com/55110771/86204856-66b7f900-bb1d-11ea-822d-196a538c11d9.png)

This PR:
![Screen Shot 2020-06-30 at 9 51 31 PM](https://user-images.githubusercontent.com/55110771/86204874-70416100-bb1d-11ea-8d70-7381e20c57cb.png)
