### PR TITLE
adding filter 6.6 in the build scan listener

### DIFF
--- a/talaiot/src/main/kotlin/com/cdsap/talaiot/metrics/GradleScanLinkMetric.kt
+++ b/talaiot/src/main/kotlin/com/cdsap/talaiot/metrics/GradleScanLinkMetric.kt
@@ -20,7 +20,8 @@ class GradleScanLinkMetric : BuildResultMetric<String?>(
         val services = gradleInternal.services
 
         when {
-            GradleVersion.current() > GradleVersion.version("5.0") -> {
+            GradleVersion.current() > GradleVersion.version("5.0")
+                    &&  GradleVersion.current() < GradleVersion.version("6.6") -> {
                 services.get(
                     DefaultBuildScanEndOfBuildNotifier::class.java
                 ) as DefaultBuildScanEndOfBuildNotifier


### PR DESCRIPTION
Using Talaiot `1.3.4` with Gradle 6.6 is breaking builds:
```
Failed to notify build listener.
> org/gradle/internal/scan/eob/DefaultBuildScanEndOfBuildNotifier
```

I'm not aware of the changes in the API and we would need to consider the next steps for this metric. When we compile the project with 6.6 we have:
```
Unresolved reference: DefaultBuildScanEndOfBuildNotifier
```

applying simple check  (thanks for the suggestion @pavel-vasilev). 

I'm merging and bumping new version to avoid blocking people

