### PR TITLE
Creating buildsrc talaiot plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 talaiot/out/**
 /build
 /talaiot/build/**
+/buildSrc/build
 /captures
 .externalNativeBuild
 .kotlintest

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,36 @@
+plugins {
+    `java-gradle-plugin`
+    `kotlin-dsl`
+}
+
+repositories {
+    google()
+    jcenter()
+    mavenCentral()
+    maven {
+        url = uri("https://plugins.gradle.org/m2/")
+    }
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72")
+    implementation("com.gradle.publish:plugin-publish-plugin:0.12.0")
+    testImplementation("junit:junit:4.12")
+}
+
+gradlePlugin {
+    plugins {
+        register("PluginTalaiot") {
+            id = "talaiotPlugin"
+            implementationClass = "com.talaiot.buildplugins.TalaiotPlugin"
+        }
+        register("PluginPublisher") {
+            id = "publisherPlugin"
+            implementationClass = "com.talaiot.buildplugins.PublisherPlugin"
+        }
+        register("CorePublisher") {
+            id = "corePlugin"
+            implementationClass = "com.talaiot.buildplugins.CorePlugin"
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/com/talaiot/buildplugins/CollectUnitTest.kt
+++ b/buildSrc/src/main/kotlin/com/talaiot/buildplugins/CollectUnitTest.kt
@@ -1,0 +1,27 @@
+package com.talaiot.buildplugins
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.testing.TestReport
+import org.gradle.kotlin.dsl.closureOf
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.get
+
+fun Project.collectUnitTest() = this.run {
+    afterEvaluate {
+        val testTask = if (rootProject.tasks.findByPath("collectUnitTest") == null) {
+            rootProject.tasks.create("collectUnitTest", TestReport::class) {
+            }
+        } else {
+            rootProject.tasks["collectUnitTest"]
+        }
+        val pr = this
+        testTask.configure(closureOf<TestReport> {
+            group = "Verification"
+            description = "Collect all tests"
+
+            val testTask = pr.tasks.find { it.name == "test" }
+            testTask?.let { reportOn(testTask) }
+            destinationDir = file("${rootProject.buildDir}/reports/tests")
+        })
+    }
+}

--- a/buildSrc/src/main/kotlin/com/talaiot/buildplugins/TalaiotPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/talaiot/buildplugins/TalaiotPlugin.kt
@@ -1,0 +1,130 @@
+package com.talaiot.buildplugins
+
+import com.gradle.publish.PluginBundleExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.*
+import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
+import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
+import org.gradle.testing.jacoco.tasks.JacocoReport
+
+import java.io.File
+import java.net.URI
+
+
+class TalaiotPlugin : Plugin<Project> {
+
+    override fun apply(target: Project) {
+        val extension = target
+            .extensions
+            .create<TalaiotPluginExtension>("talaiotPlugin")
+
+        println(extension)
+        target.plugins.apply("java-gradle-plugin")
+        target.plugins.apply("maven-publish")
+        target.plugins.apply("jacoco")
+        target.plugins.apply("kotlin")
+        target.plugins.apply("com.gradle.plugin-publish")
+
+        target.repositories {
+            jcenter()
+            mavenCentral()
+        }
+
+        target.dependencies {
+            add("testImplementation", "com.nhaarman.mockitokotlin2:mockito-kotlin:2.0.0-RC1")
+            add("testImplementation", "io.kotlintest:kotlintest-runner-junit5:3.3.2")
+        }
+
+        target.tasks.withType<JacocoReport> {
+            reports {
+                xml.isEnabled = true
+                csv.isEnabled = true
+                html.isEnabled = true
+                html.destination = File("${target.rootProject.buildDir}/coverage")
+            }
+        }
+        target.configure<JacocoPluginExtension> {
+            toolVersion = "0.8.3"
+        }
+
+        target.apply {
+            val test by target.tasks.getting(Test::class) {
+                useJUnitPlatform { }
+            }
+        }
+        target.version =  Versions.TALAIOT_VERSION
+        target.afterEvaluate {
+            collectUnitTest()
+            setTalaiotPluginGroup(target)
+            setTalaiotPluginVersion(target)
+            configGradlePlugin(target)
+            configPublishing(target)
+        }
+    }
+
+    private fun configPublishing(target: Project) {
+        target.configure<PublishingExtension> {
+            repositories {
+                maven {
+                    name = "Snapshots"
+                    url = URI("http://oss.jfrog.org/artifactory/oss-snapshot-local")
+
+                    credentials {
+                        username = System.getenv("USERNAME_SNAPSHOT")
+                        password = System.getenv("PASSWORD_SNAPSHOT")
+                    }
+                }
+            }
+
+            publications {
+                create<MavenPublication>("maven") {
+                    val extension = target.extensions.getByType<TalaiotPluginExtension>()
+                    groupId = target.group.toString()
+                    artifactId = extension.artifact
+                    version = target.version.toString()
+                    from(target.components["kotlin"])
+                }
+            }
+        }
+    }
+
+    private fun setTalaiotPluginGroup(target: Project) {
+        val extension = target.extensions.getByType<TalaiotPluginExtension>()
+        target.group = extension.group ?: "com.cdsap.talaiot.plugin"
+    }
+
+    private fun setTalaiotPluginVersion(target: Project) {
+        val extension = target.extensions.getByType<TalaiotPluginExtension>()
+        target.version = extension.version ?: Versions.TALAIOT_VERSION
+    }
+
+    private fun configGradlePlugin(project: Project) {
+
+        project.configure<GradlePluginDevelopmentExtension> {
+            plugins {
+                register(project.name) {
+                    val extension = project.extensions.getByType<TalaiotPluginExtension>()
+                    id = extension.idPlugin
+                    implementationClass = extension.mainClass
+                }
+            }
+        }
+
+        project.configure<PluginBundleExtension>() {
+            (plugins){
+                (project.name){
+                    val extension = project.extensions.getByType<TalaiotPluginExtension>()
+                    displayName = project.name
+                    description =
+                        "Simple and extensible plugin to track task and build times in your Gradle Project."
+                    tags = listOf("tracking", "kotlin", "gradle")
+                    version = Versions.TALAIOT_VERSION
+                }
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/com/talaiot/buildplugins/TalaiotPluginExtension.kt
+++ b/buildSrc/src/main/kotlin/com/talaiot/buildplugins/TalaiotPluginExtension.kt
@@ -1,0 +1,46 @@
+package com.talaiot.buildplugins
+
+import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
+
+/**
+ * Plugin Extension to configure a [TalaiotPlugin]
+ * In this extension we define the parameters required for naming and publishing.
+ *
+ * talaiotPlugin {
+ *     idPlugin = "com.cdsap.talaiot"
+ *     artifact = "talaiot"
+ *     group = "com.cdsap"
+ *     mainClass = "com.cdsap.talaiot.TalaiotPlugin"
+ *     version = "1.3.6-SNAPSHOT"
+ * }
+ *
+ *
+ */
+open class TalaiotPluginExtension {
+    /**
+     * Plugin's Gradle id. This id will be used by the final consumer and the [GradlePluginDevelopmentExtension]
+     * example: apply plugin: "com.cdsap.talaiot.plugin.base"
+     */
+    var idPlugin : String? = null
+
+    /**
+     *  Deployment for snapshots/maven local requires inform about the artifact coordinates of the
+     *  new artifact
+     */
+    var artifact : String? = null
+    /**
+     *  Deployment for snapshots/maven local requires inform about the group coordinates of the
+     *  new artifact. If it's not informed uses the default group of the type of plugins [TalaiotPlugin]
+     */
+    var group : String? = null
+
+    /**
+     * Main Class of the plugin, required by the [GradlePluginDevelopmentExtension]
+     */
+    var mainClass: String? = null
+    /**
+     * Specific version for the plugin
+     * If it's not informed will use version from [Versions]
+     */
+    var version : String? = null
+}

--- a/buildSrc/src/main/kotlin/com/talaiot/buildplugins/Versions.kt
+++ b/buildSrc/src/main/kotlin/com/talaiot/buildplugins/Versions.kt
@@ -1,0 +1,5 @@
+package com.talaiot.buildplugins
+
+object Versions {
+    const val TALAIOT_VERSION = "1.4.0-SNAPSHOT"
+}

--- a/buildSrc/src/test/kotlin/com/talaiot/buildplugins/TalaiotPluginTest.kt
+++ b/buildSrc/src/test/kotlin/com/talaiot/buildplugins/TalaiotPluginTest.kt
@@ -1,0 +1,244 @@
+package com.talaiot.buildplugins
+
+import org.gradle.testkit.runner.BuildResult
+import org.junit.Test
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+
+class TalaiotPluginTest {
+
+    @Test
+    fun pluginIsAppliedCorrectly() {
+        val rootFolder = createTempFolder()
+        File(rootFolder, "build.gradle").appendText(
+            """
+             plugins{
+                  id 'java'
+                  id 'talaiotPlugin'
+              }  
+              
+              talaiotPlugin {
+                  idPlugin = "com.cdsap.talaiot"
+                   artifact = "talaiot"
+                   group = "com.cdsap"
+                   mainClass = "com.cdsap.talaiot.TalaiotPlugin"
+                   version = "1.3.6-SNAPSHOT"
+              }
+         """.trimIndent()
+        )
+
+        val result = buildResult(rootFolder, "assemble")
+        assert(result.task(":assemble")?.outcome == TaskOutcome.SUCCESS)
+
+        rootFolder.deleteRecursively()
+    }
+
+    @Test
+    fun pluginWithoutExtensionFails() {
+        val rootFolder = createTempFolder()
+        File(rootFolder, "build.gradle").appendText(
+            """
+             plugins{
+                  id 'java'
+                  id 'talaiotPlugin'
+              }  
+             
+         """.trimIndent()
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(rootFolder)
+            .withArguments("assemble")
+            .withPluginClasspath()
+            .buildAndFail()
+        assert(result.task(":pluginDescriptors")?.outcome == TaskOutcome.FAILED)
+
+        rootFolder.deleteRecursively()
+    }
+
+    @Test
+    fun pluginIncludesGradlePluginPublisherTasks() {
+        val rootFolder = createTempFolder()
+        File(rootFolder, "build.gradle").appendText(
+            buildGradleWithTalaiotAndJava().trimIndent()
+        )
+
+        val result = buildResult(rootFolder, "tasks")
+        assert(result.output.contains("publishPlugins"))
+
+        rootFolder.deleteRecursively()
+    }
+
+    @Test
+    fun pluginIncludesPublishGeneralTasks() {
+        val rootFolder = createTempFolder()
+        File(rootFolder, "build.gradle").appendText(
+            buildGradleWithTalaiotAndJava().trimIndent()
+        )
+
+        val result = buildResult(rootFolder, "tasks")
+        assert(result.output.contains("publishToMavenLocal"))
+
+        rootFolder.deleteRecursively()
+    }
+
+    @Test
+    fun pluginAppliesGenericVersion() {
+        val rootFolder = createTempFolder()
+        File(rootFolder, "build.gradle").appendText(
+            buildGradleWithTalaiotAndCustomRepositoryNoVersion(rootFolder.absolutePath).trimIndent()
+        )
+
+        buildResult(rootFolder, "publishMavenPublicationToTestRepo")
+
+        assert(
+            File("${rootFolder.absoluteFile}/repo/com/cdsap/talaiot//${Versions.TALAIOT_VERSION}")
+                .walkTopDown().filter {
+                    it.name.contains("talaiot-")
+                }.count() > 0
+        )
+        rootFolder.deleteRecursively()
+    }
+
+    @Test
+    fun pluginAppliesGenericGroup() {
+        val rootFolder = createTempFolder()
+        println(rootFolder.absolutePath)
+        File(rootFolder, "build.gradle").appendText(
+            buildGradleWithTalaiotAndCustomRepositoryNoGroup(rootFolder.absolutePath).trimIndent()
+        )
+
+        buildResult(rootFolder, "publishMavenPublicationToTestRepo")
+
+        assert(
+            File("${rootFolder.absoluteFile}/repo/com/cdsap/talaiot/plugin/talaiot/${Versions.TALAIOT_VERSION}")
+                .walkTopDown().filter {
+                    it.name.contains("talaiot-")
+                }.count() > 0
+        )
+        rootFolder.deleteRecursively()
+    }
+
+    @Test
+    fun pluginOverrideVersionAndGroup() {
+        val rootFolder = createTempFolder()
+        File(rootFolder, "build.gradle").appendText(
+            buildGradleWithTalaiotAndCustomRepositoryAndVerionGroup(rootFolder.absolutePath).trimIndent()
+        )
+
+        buildResult(rootFolder, "publishMavenPublicationToTestRepo")
+
+        assert(File("${rootFolder.absoluteFile}/repo/com/cdsap/overridegroup/talaiot/1.3.6/talaiot-1.3.6.jar").exists())
+        rootFolder.deleteRecursively()
+    }
+
+    private fun createTempFolder(): File {
+        val createdFolder = File.createTempFile("test", "", null)
+        createdFolder.delete()
+        createdFolder.mkdir()
+        return createdFolder
+    }
+
+    private fun buildResult(rootFolder: File, command: String): BuildResult {
+        return GradleRunner.create()
+            .withProjectDir(rootFolder)
+            .withArguments(command)
+            .withPluginClasspath()
+            .build()
+    }
+
+
+    private fun buildGradleWithTalaiotAndJava(): String {
+        return """
+                 plugins{
+                      id 'java'
+                      id 'talaiotPlugin'
+                  }  
+                  
+                  talaiotPlugin {
+                      idPlugin = "com.cdsap.talaiot"
+                       artifact = "talaiot"
+                       group = "com.cdsap"
+                       mainClass = "com.cdsap.talaiot.TalaiotPlugin"
+                       version = "1.3.6-SNAPSHOT"
+                  }
+                 
+             """
+    }
+
+    private fun buildGradleWithTalaiotAndCustomRepositoryAndVerionGroup(testProjectDir: String): String {
+        return """
+                  plugins{
+                      id 'java'
+                      id 'talaiotPlugin'
+                  }  
+                  
+                  talaiotPlugin {
+                       idPlugin = "com.cdsap.talaiot"
+                       artifact = "talaiot"
+                       group = "com.cdsap.overridegroup"
+                       mainClass = "com.cdsap.talaiot.TalaiotPlugin"
+                       version = "1.3.6"
+                  }
+                   
+                   publishing {
+                          repositories {
+                               maven {
+                                 name = "testRepo"
+                                 url = uri("$testProjectDir/repo")
+                               }
+                           }
+                   }
+                """
+    }
+
+    private fun buildGradleWithTalaiotAndCustomRepositoryNoVersion(testProjectDir: String): String {
+        return """
+                  plugins{
+                      id 'java'
+                      id 'talaiotPlugin'
+                  }  
+                  
+                  talaiotPlugin {
+                       idPlugin = "com.cdsap.talaiot"
+                       artifact = "talaiot"
+                       group = "com.cdsap"
+                       mainClass = "com.cdsap.talaiot.TalaiotPlugin"
+                  }
+                   
+                   publishing {
+                          repositories {
+                               maven {
+                                 name = "testRepo"
+                                 url = uri("$testProjectDir/repo")
+                               }
+                           }
+                   }
+                """
+    }
+
+    private fun buildGradleWithTalaiotAndCustomRepositoryNoGroup(testProjectDir: String): String {
+        return """
+                  plugins{
+                      id 'java'
+                      id 'talaiotPlugin'
+                  }  
+                  
+                  talaiotPlugin {
+                       idPlugin = "com.cdsap.talaiot"
+                       artifact = "talaiot"
+                       mainClass = "com.cdsap.talaiot.TalaiotPlugin"
+                  }
+                   
+                   publishing {
+                          repositories {
+                               maven {
+                                 name = "testRepo"
+                                 url = uri("$testProjectDir/repo")
+                               }
+                           }
+                   }
+                """
+    }
+}

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.3.50"
+   // kotlin("jvm") version "1.3.50"
     id("com.eden.orchidPlugin") version "0.17.1"
 
 }

--- a/docs/build.gradle.kts
+++ b/docs/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-   // kotlin("jvm") version "1.3.50"
+    kotlin("jvm")
     id("com.eden.orchidPlugin") version "0.17.1"
 
 }

--- a/talaiot/build.gradle.kts
+++ b/talaiot/build.gradle.kts
@@ -1,89 +1,27 @@
 plugins {
-    `java-gradle-plugin`
     `kotlin-dsl`
-    `maven-publish`
-    id("jacoco")
-    kotlin("jvm") version "1.3.60"
-    id("com.gradle.plugin-publish") version "0.12.0"
+    id("talaiotPlugin")
 }
 
-jacoco {
-    toolVersion = "0.8.3"
+talaiotPlugin{
+    idPlugin = "com.cdsap.talaiot"
+    artifact = "talaiot"
+    group = "com.cdsap"
+    mainClass = "com.cdsap.talaiot.TalaiotPlugin"
+    version = "1.3.6-SNAPSHOT"
 }
 
-val versionTalaiot = "1.3.5-SNAPSHOT"
-
-group = "com.cdsap"
-version = versionTalaiot
-
-gradlePlugin {
-    plugins {
-        register("Talaiot") {
-            id = "com.cdsap.talaiot"
-            implementationClass = "com.cdsap.talaiot.TalaiotPlugin"
-        }
-        dependencies {
-            implementation("io.github.rybalkinsd:kohttp:0.10.0")
-            implementation("guru.nidi:graphviz-java:0.8.3")
-            implementation("org.influxdb:influxdb-java:2.19")
-            implementation("com.github.oshi:oshi-core:3.13.3")
-            implementation("com.google.code.gson:gson:2.8.5")
-            implementation("org.elasticsearch.client:elasticsearch-rest-high-level-client:7.3.0")
-            implementation("com.rethinkdb:rethinkdb-driver:2.3.3")
-            testImplementation("io.kotlintest:kotlintest-runner-junit5:3.3.2")
-            testImplementation(gradleTestKit())
-            testImplementation("org.testcontainers:testcontainers:1.11.3")
-            testImplementation("org.testcontainers:influxdb:1.11.3")
-            testImplementation("org.testcontainers:elasticsearch:1.12.0")
-            testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.0.0-RC1")
-        }
-    }
+dependencies {
+    implementation("io.github.rybalkinsd:kohttp:0.10.0")
+    implementation("guru.nidi:graphviz-java:0.8.3")
+    implementation("org.influxdb:influxdb-java:2.19")
+    implementation("com.github.oshi:oshi-core:3.13.3")
+    implementation("com.google.code.gson:gson:2.8.5")
+    implementation("org.elasticsearch.client:elasticsearch-rest-high-level-client:7.3.0")
+    implementation("com.rethinkdb:rethinkdb-driver:2.3.3")
+    testImplementation(gradleTestKit())
+    testImplementation("org.testcontainers:testcontainers:1.11.3")
+    testImplementation("org.testcontainers:influxdb:1.11.3")
+    testImplementation("org.testcontainers:elasticsearch:1.12.0")
 }
 
-pluginBundle {
-    website = "https://github.com/cdsap/Talaiot/"
-    vcsUrl = "https://github.com/cdsap/Talaiot/"
-    tags = listOf("kotlin", "gradle", "kotlin-dsl")
-    (plugins) {
-        "Talaiot" {
-            displayName = "Talaiot"
-            description = "Simple and extensible plugin to track task and build times in your Gradle Project."
-            tags = listOf("tracking", "kotlin", "gradle")
-            version = versionTalaiot
-        }
-    }
-}
-
-publishing {
-    repositories {
-        maven {
-            name = "Snapshots"
-            url = uri("http://oss.jfrog.org/artifactory/oss-snapshot-local")
-
-            credentials {
-                username = System.getenv("USERNAME_SNAPSHOT")
-                password = System.getenv("PASSWORD_SNAPSHOT")
-            }
-        }
-    }
-}
-
-val test by tasks.getting(Test::class) {
-    useJUnitPlatform { }
-}
-
-repositories {
-    jcenter()
-    mavenCentral()
-    google()
-    mavenLocal()
-}
-
-tasks.jacocoTestReport {
-    reports {
-        xml.isEnabled = true
-        csv.isEnabled = true
-        html.isEnabled = true
-        html.destination = file("$buildDir/reports/coverage")
-    }
-}


### PR DESCRIPTION

First PR to apply the migration defined https://docs.google.com/document/d/1hBFNb-pCbX7P1rlHe9-y3vcGbMDLR9ve7sZwUfqluU0/edit# and discussed here https://github.com/cdsap/Talaiot/issues/164

**Context**
Current Talaiot module will be the foundation for the base of the library, we still need to provide an entry point and we will use the plugins components. In this early stage, we need still to use Talaiot as main module to give compatibility for Talaiot < 1.4 but still we can abstract the build Logic

**PR**
This PR adds the new `TalaiotPlugin`, this is a build plugin that helps to create new plugins abstracting the publishing configuration. 
Current Talaiot module has been migrated and is using the plugin convention:
```
talaiotPlugin{
    idPlugin = "com.cdsap.talaiot"
    artifact = "talaiot"
    group = "com.cdsap"
    mainClass = "com.cdsap.talaiot.TalaiotPlugin"
    version = "1.3.6-SNAPSHOT"
}
```

#204
