### PR TITLE
 Move Graphviz dependencies to Graph Publisher 

### DIFF
--- a/library/core/talaiot/build.gradle.kts
+++ b/library/core/talaiot/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 dependencies {
     api(project(":library:core:talaiot-logger"))
     api(project(":library:core:talaiot-request"))
-    api("guru.nidi:graphviz-java:0.8.3")
     implementation("com.github.oshi:oshi-core:3.13.3")
     testImplementation("io.github.rybalkinsd:kohttp:0.10.0")
     testImplementation(project(":library:core:talaiot-test-utils"))

--- a/library/plugins/graph/graph-publisher/build.gradle.kts
+++ b/library/plugins/graph/graph-publisher/build.gradle.kts
@@ -5,5 +5,6 @@ plugins {
 
 dependencies {
     implementation(project(":library:core:talaiot"))
+    implementation("guru.nidi:graphviz-java:0.8.3")
     testImplementation(project(":library:core:talaiot-test-utils"))
 }

--- a/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/DefaultDiskPublisher.kt
+++ b/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/DefaultDiskPublisher.kt
@@ -4,7 +4,7 @@ import com.cdsap.talaiot.entities.ExecutionReport
 import com.cdsap.talaiot.entities.TaskDependencyNode
 import com.cdsap.talaiot.entities.TaskMessageState
 import com.cdsap.talaiot.logger.LogTracker
-import com.cdsap.talaiot.writer.FileWriter
+import com.cdsap.talaiot.publisher.graph.writer.FileWriter
 
 /**
  * Abstract class implementing DiskPublisher.

--- a/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/DiskPublisher.kt
+++ b/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/DiskPublisher.kt
@@ -2,7 +2,7 @@ package com.cdsap.talaiot.publisher.graph
 
 import com.cdsap.talaiot.logger.LogTracker
 import com.cdsap.talaiot.publisher.Publisher
-import com.cdsap.talaiot.writer.FileWriter
+import com.cdsap.talaiot.publisher.graph.writer.FileWriter
 
 
 /**

--- a/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/DotPublisher.kt
+++ b/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/DotPublisher.kt
@@ -4,7 +4,7 @@ package com.cdsap.talaiot.publisher.graph
 import com.cdsap.talaiot.entities.ExecutionReport
 import com.cdsap.talaiot.entities.TaskMessageState
 import com.cdsap.talaiot.logger.LogTracker
-import com.cdsap.talaiot.writer.FileWriter
+import com.cdsap.talaiot.publisher.graph.writer.FileWriter
 import guru.nidi.graphviz.attribute.RankDir
 import guru.nidi.graphviz.engine.Engine
 import guru.nidi.graphviz.engine.Format

--- a/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/GexfPublisher.kt
+++ b/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/GexfPublisher.kt
@@ -4,7 +4,7 @@ import com.cdsap.talaiot.entities.ExecutionReport
 import com.cdsap.talaiot.entities.TaskMessageState
 import com.cdsap.talaiot.logger.LogTracker
 import com.cdsap.talaiot.publisher.graph.resources.ResourcesGexf
-import com.cdsap.talaiot.writer.FileWriter
+import com.cdsap.talaiot.publisher.graph.writer.FileWriter
 import java.util.concurrent.Executor
 
 /**

--- a/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/GraphPublisherFactory.kt
+++ b/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/GraphPublisherFactory.kt
@@ -1,7 +1,7 @@
 package com.cdsap.talaiot.publisher.graph
 
 import com.cdsap.talaiot.logger.LogTracker
-import com.cdsap.talaiot.writer.FileWriter
+import com.cdsap.talaiot.publisher.graph.writer.FileWriter
 import java.util.concurrent.Executor
 
 /**

--- a/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/GraphPublisherFactoryImpl.kt
+++ b/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/GraphPublisherFactoryImpl.kt
@@ -1,7 +1,7 @@
 package com.cdsap.talaiot.publisher.graph
 
 import com.cdsap.talaiot.logger.LogTracker
-import com.cdsap.talaiot.writer.FileWriter
+import com.cdsap.talaiot.publisher.graph.writer.FileWriter
 import java.util.concurrent.Executor
 
 class GraphPublisherFactoryImpl

--- a/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/HtmlPublisher.kt
+++ b/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/HtmlPublisher.kt
@@ -5,7 +5,7 @@ import com.cdsap.talaiot.entities.TaskMessageState
 import com.cdsap.talaiot.logger.LogTracker
 import com.cdsap.talaiot.publisher.graph.resources.ResourcesHtml
 import com.cdsap.talaiot.publisher.graph.resources.ResourcesHtml.LEGEND_HEADER
-import com.cdsap.talaiot.writer.FileWriter
+import com.cdsap.talaiot.publisher.graph.writer.FileWriter
 import java.util.concurrent.Executor
 
 /**

--- a/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/TaskDependencyGraphPublisher.kt
+++ b/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/TaskDependencyGraphPublisher.kt
@@ -3,8 +3,8 @@ package com.cdsap.talaiot.publisher.graph
 import com.cdsap.talaiot.entities.ExecutionReport
 import com.cdsap.talaiot.logger.LogTracker
 import com.cdsap.talaiot.publisher.Publisher
-import com.cdsap.talaiot.writer.DotWriter
-import com.cdsap.talaiot.writer.TaskGraphWriter
+import com.cdsap.talaiot.publisher.graph.writer.DotWriter
+import com.cdsap.talaiot.publisher.graph.writer.TaskGraphWriter
 import java.util.concurrent.Executor
 
 /**

--- a/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/writer/DotWriter.kt
+++ b/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/writer/DotWriter.kt
@@ -1,15 +1,15 @@
-package com.cdsap.talaiot.writer
+package com.cdsap.talaiot.publisher.graph.writer
 
 import com.cdsap.talaiot.logger.LogTracker
-import com.cdsap.talaiot.writer.FileWriter.Companion.TALAIOT_OUTPUT_DIR
+import com.cdsap.talaiot.publisher.graph.writer.FileWriter.Companion.TALAIOT_OUTPUT_DIR
+import guru.nidi.graphviz.engine.Renderer
 import org.gradle.api.Project
 import java.io.File
-import java.nio.file.Files
 
 /**
- * Implementation of FileWriter to writes bytes to a file
+ * Implementation of FileWriter using Renderer from GraphViz library
  */
-class TaskGraphWriter(
+class DotWriter(
     override var project: Project,
     override var logTracker: LogTracker
 ) : FileWriter {
@@ -21,8 +21,8 @@ class TaskGraphWriter(
         val file = File(dir, name)
 
         createFile {
-            if (content is String) {
-                Files.write(file.toPath(), content.toByteArray())
+            if (content is Renderer) {
+                content.toFile(file)
             }
         }
     }

--- a/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/writer/FileWriter.kt
+++ b/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/writer/FileWriter.kt
@@ -1,4 +1,4 @@
-package com.cdsap.talaiot.writer
+package com.cdsap.talaiot.publisher.graph.writer
 
 import com.cdsap.talaiot.logger.LogTracker
 import org.gradle.api.Project

--- a/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/writer/TaskGraphWriter.kt
+++ b/library/plugins/graph/graph-publisher/src/main/java/com/cdsap/talaiot/publisher/graph/writer/TaskGraphWriter.kt
@@ -1,15 +1,15 @@
-package com.cdsap.talaiot.writer
+package com.cdsap.talaiot.publisher.graph.writer
 
 import com.cdsap.talaiot.logger.LogTracker
-import com.cdsap.talaiot.writer.FileWriter.Companion.TALAIOT_OUTPUT_DIR
-import guru.nidi.graphviz.engine.Renderer
+import com.cdsap.talaiot.publisher.graph.writer.FileWriter.Companion.TALAIOT_OUTPUT_DIR
 import org.gradle.api.Project
 import java.io.File
+import java.nio.file.Files
 
 /**
- * Implementation of FileWriter using Renderer from GraphViz library
+ * Implementation of FileWriter to writes bytes to a file
  */
-class DotWriter(
+class TaskGraphWriter(
     override var project: Project,
     override var logTracker: LogTracker
 ) : FileWriter {
@@ -21,8 +21,8 @@ class DotWriter(
         val file = File(dir, name)
 
         createFile {
-            if (content is Renderer) {
-                content.toFile(file)
+            if (content is String) {
+                Files.write(file.toPath(), content.toByteArray())
             }
         }
     }

--- a/library/plugins/graph/graph-publisher/src/test/java/com/cdsap/talaiot/publisher/graph/DotPublisherTest.kt
+++ b/library/plugins/graph/graph-publisher/src/test/java/com/cdsap/talaiot/publisher/graph/DotPublisherTest.kt
@@ -2,7 +2,7 @@ package com.cdsap.talaiot.publisher.graph
 
 import com.cdsap.talaiot.logger.LogTracker
 import com.cdsap.talaiot.utils.TestExecutor
-import com.cdsap.talaiot.writer.FileWriter
+import com.cdsap.talaiot.publisher.graph.writer.FileWriter
 import com.nhaarman.mockitokotlin2.*
 import io.kotlintest.specs.BehaviorSpec
 

--- a/library/plugins/graph/graph-publisher/src/test/java/com/cdsap/talaiot/publisher/graph/GexfPublisherTest.kt
+++ b/library/plugins/graph/graph-publisher/src/test/java/com/cdsap/talaiot/publisher/graph/GexfPublisherTest.kt
@@ -3,7 +3,7 @@ package com.cdsap.talaiot.publisher.graph
 import com.cdsap.talaiot.publisher.graph.resources.ResourcesGexf
 import com.cdsap.talaiot.logger.LogTracker
 import com.cdsap.talaiot.utils.TestExecutor
-import com.cdsap.talaiot.writer.FileWriter
+import com.cdsap.talaiot.publisher.graph.writer.FileWriter
 import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify

--- a/library/plugins/graph/graph-publisher/src/test/java/com/cdsap/talaiot/publisher/graph/GraphPublisherFactoryTest.kt
+++ b/library/plugins/graph/graph-publisher/src/test/java/com/cdsap/talaiot/publisher/graph/GraphPublisherFactoryTest.kt
@@ -3,7 +3,7 @@ package com.cdsap.talaiot.publisher.graph
 import com.cdsap.talaiot.logger.LogTracker
 import com.cdsap.talaiot.publisher.Publisher
 import com.cdsap.talaiot.utils.TestExecutor
-import com.cdsap.talaiot.writer.FileWriter
+import com.cdsap.talaiot.publisher.graph.writer.FileWriter
 import com.nhaarman.mockitokotlin2.*
 import io.kotlintest.specs.BehaviorSpec
 

--- a/library/plugins/graph/graph-publisher/src/test/java/com/cdsap/talaiot/publisher/graph/HtmlPublisherTest.kt
+++ b/library/plugins/graph/graph-publisher/src/test/java/com/cdsap/talaiot/publisher/graph/HtmlPublisherTest.kt
@@ -5,7 +5,7 @@ import com.cdsap.talaiot.logger.LogTracker
 import com.cdsap.talaiot.publisher.graph.TaskMeasurementAggregatedMock.taskMeasurementAggregated
 import com.cdsap.talaiot.publisher.graph.resources.ResourcesHtml.LEGEND_HEADER
 import com.cdsap.talaiot.utils.TestExecutor
-import com.cdsap.talaiot.writer.FileWriter
+import com.cdsap.talaiot.publisher.graph.writer.FileWriter
 import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify


### PR DESCRIPTION
### Summary

- Move writer classes that depend on `graphviz-java` from `core:talaiot` into `graph-publisher`.
- Remove `graphviz-java` dependency from `core:talaiot`

Solves #244 