### PR TITLE
adding jfrog, conf and adding the correct publishers

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,6 +13,7 @@ repositories {
 }
 
 dependencies {
+    implementation("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72")
     implementation("com.gradle.publish:plugin-publish-plugin:0.12.0")
     testImplementation("junit:junit:4.12")

--- a/buildSrc/src/main/kotlin/com/talaiot/buildplugins/BaseConfiguration.kt
+++ b/buildSrc/src/main/kotlin/com/talaiot/buildplugins/BaseConfiguration.kt
@@ -12,4 +12,10 @@ open class BaseConfiguration {
      * If it's not informed will use version from [Constants]
      */
     var version: String? = null
+
+    /**
+     *  Deployment for snapshots/maven local requires inform about the artifact coordinates of the
+     *  new artifact
+     */
+    var artifact: String? = null
 }

--- a/buildSrc/src/main/kotlin/com/talaiot/buildplugins/Constants.kt
+++ b/buildSrc/src/main/kotlin/com/talaiot/buildplugins/Constants.kt
@@ -1,7 +1,7 @@
 package com.talaiot.buildplugins
 
 object Constants {
-    const val TALAIOT_VERSION = "1.4.0-SNAPSHOT"
+    const val TALAIOT_VERSION = "1.4.0"
     const val DEFAULT_GROUP_PLUGIN = "com.cdsap.talaiot.plugin"
     const val DEFAULT_GROUP_LIBRARY = "com.cdsap.talaiot"
 }

--- a/buildSrc/src/main/kotlin/com/talaiot/buildplugins/GradlePublishingExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/talaiot/buildplugins/GradlePublishingExtensions.kt
@@ -2,17 +2,20 @@ package com.talaiot.buildplugins
 
 import com.gradle.publish.PluginBundleExtension
 import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.invoke
+import org.gradle.kotlin.dsl.named
 import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
 
-fun Project.setUpGradlePublishing(){
+fun Project.setUpGradlePublishing() {
+    val extension = project.extensions.getByType<TalaiotPluginConfiguration>()
 
     configure<GradlePluginDevelopmentExtension> {
         plugins {
             register(project.name) {
-                val extension = project.extensions.getByType<TalaiotPluginConfiguration>()
                 id = extension.idPlugin
                 implementationClass = extension.mainClass
             }
@@ -22,12 +25,21 @@ fun Project.setUpGradlePublishing(){
     configure<PluginBundleExtension>() {
         (plugins){
             (name){
-                val extension = project.extensions.getByType<TalaiotPluginConfiguration>()
-                displayName = project.name
+                displayName = extension.displayName
+                website = "https://github.com/cdsap/Talaiot"
+                vcsUrl = "https://github.com/cdsap/Talaiot"
                 description =
-                    "Simple and extensible plugin to track task and build times in your Gradle Project."
+                    "${extension.displayName}, simple and extensible plugin to track task and build times in your Gradle Project."
                 tags = listOf("tracking", "kotlin", "gradle")
-                version = Constants.TALAIOT_VERSION
+                version = extension.version
+            }
+        }
+    }
+
+    configure<PublishingExtension> {
+        publications {
+            named<MavenPublication>("pluginMaven") {
+                artifactId = extension.artifact
             }
         }
     }

--- a/buildSrc/src/main/kotlin/com/talaiot/buildplugins/JFrogExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/talaiot/buildplugins/JFrogExtensions.kt
@@ -1,0 +1,26 @@
+package com.talaiot.buildplugins
+
+
+
+import com.jfrog.bintray.gradle.BintrayExtension
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getByType
+
+fun Project.setUpJfrog() {
+    val extension = extensions.getByType<BaseConfiguration>()
+    configure<BintrayExtension> {
+        user = System.getenv("USERNAME_BINTRAY")
+        key =  System.getenv("KEY_BINTRAY")
+        setPublications("TalaiotLib")
+
+        pkg.apply {
+            publish = true
+            repo = "Talaiot"
+            name = extension.artifact
+            userOrg = "cdsap"
+            setLicenses("MIT")
+            vcsUrl = "https://github.com/cdsap/Talaiot"
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/com/talaiot/buildplugins/PublishingExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/talaiot/buildplugins/PublishingExtensions.kt
@@ -1,24 +1,30 @@
 package com.talaiot.buildplugins
 
 import org.gradle.api.Project
-import org.gradle.api.attributes.LibraryElements
-import org.gradle.api.component.AdhocComponentWithVariants
-import org.gradle.api.file.CopySpec
-import org.gradle.api.plugins.JavaLibraryPlugin
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.api.tasks.javadoc.Javadoc
-import org.gradle.jvm.tasks.Jar
+import org.gradle.api.tasks.bundling.Jar
 import org.gradle.kotlin.dsl.*
-import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import java.net.URI
 
 fun Project.setUpPublishing(
-    namePublication: String,
-    configurationArtifactId: String?
+    type: Type
 ) {
 
-    this.configure<PublishingExtension> {
+    val extension = if (type == Type.LIBRARY) {
+        extensions.getByType<BaseConfiguration>()
+    } else {
+        extensions.getByType<TalaiotPluginConfiguration>()
+    }
+    val artifcact = getArtifact(extension.artifact, this)
+
+    configure<JavaPluginExtension> {
+        withJavadocJar()
+        withSourcesJar()
+    }
+    configure<PublishingExtension> {
+
         repositories {
             maven {
                 name = "Snapshots"
@@ -33,15 +39,47 @@ fun Project.setUpPublishing(
 
         publications {
 
-            register(namePublication, MavenPublication::class) {
-                artifactId = getArtifact(configurationArtifactId, project)
-                from(components["java"])
+            register("TalaiotLib", MavenPublication::class) {
+                from(components.findByName("java"))
+                artifactId = artifcact
                 versionMapping {
                     usage("java-api") {
                         fromResolutionOf("runtimeClasspath")
                     }
                     usage("java-runtime") {
                         fromResolutionResult()
+                    }
+                }
+                pom {
+                    name.set("Talaiot")
+                    url.set("https://github.com/cdsap/Talaiot/")
+                    description.set(
+                        "is a simple and extensible plugin to track timing in your Gradle Project."
+                    )
+                    licenses {
+                        license {
+                            name.set("The MIT License (MIT)")
+                            url.set("http://opensource.org/licenses/MIT")
+                            distribution.set("repo")
+                        }
+                    }
+                    developers {
+                        developer {
+                            id.set("Malinskiy")
+                            name.set("Anton Malinskiy")
+                        }
+                        developer {
+                            id.set("mokkun")
+                            name.set("Mozart Peter")
+                        }
+                        developer {
+                            id.set("cdsap")
+                            name.set("Inaki Villar")
+                        }
+                        developer {
+                            id.set("MyDogTom")
+                            name.set("Svyatoslav Chatchenko")
+                        }
                     }
                 }
             }
@@ -51,24 +89,23 @@ fun Project.setUpPublishing(
 
 fun Project.setProjectGroup(
     configurationGroup: String?,
-    default: String
+    type: Type
 ) {
-    group = configurationGroup ?: default
-}
-
-fun Project.setProjectGroup(
-    default: String
-) {
-    group = default
+    group = configurationGroup ?: when (type) {
+        Type.LIBRARY -> Constants.DEFAULT_GROUP_LIBRARY
+        Type.PLUGIN -> Constants.DEFAULT_GROUP_PLUGIN
+    }
 }
 
 fun Project.setProjectVersion(configurationVersion: String?) {
     version = configurationVersion ?: Constants.TALAIOT_VERSION
 }
 
-fun Project.setProjectVersion() {
-    version = Constants.TALAIOT_VERSION
-}
-
 fun getArtifact(configurationArtifactId: String?, project: Project) =
     configurationArtifactId ?: project.name
+
+
+enum class Type {
+    PLUGIN,
+    LIBRARY
+}

--- a/buildSrc/src/main/kotlin/com/talaiot/buildplugins/PublishingExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/talaiot/buildplugins/PublishingExtensions.kt
@@ -70,7 +70,7 @@ fun Project.setUpPublishing(
                         }
                         developer {
                             id.set("mokkun")
-                            name.set("Mozart Peter")
+                            name.set("Mozart Petter")
                         }
                         developer {
                             id.set("cdsap")

--- a/buildSrc/src/main/kotlin/com/talaiot/buildplugins/TalaiotKotlinLibPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/talaiot/buildplugins/TalaiotKotlinLibPlugin.kt
@@ -2,9 +2,7 @@ package com.talaiot.buildplugins
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.dependencies
-import org.gradle.kotlin.dsl.project
-import org.gradle.kotlin.dsl.repositories
+import org.gradle.kotlin.dsl.*
 
 /**
  * TalaiotKotlinLib Plugin represents a build configuration
@@ -14,10 +12,15 @@ import org.gradle.kotlin.dsl.repositories
 class TalaiotKotlinLibPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
+        target
+            .extensions
+            .create<BaseConfiguration>("talaiotLib")
+
         target.plugins.apply("kotlin")
         target.plugins.apply("maven-publish")
         target.plugins.apply("jacoco")
         target.plugins.apply("java-library")
+        target.plugins.apply("com.jfrog.bintray")
 
         target.repositories {
             jcenter()
@@ -26,12 +29,13 @@ class TalaiotKotlinLibPlugin : Plugin<Project> {
 
         target.setUpJacoco()
         target.setUpJunitPlatform()
-
         target.afterEvaluate {
-            setProjectVersion()
-            setProjectGroup(Constants.DEFAULT_GROUP_LIBRARY)
+            val extension = extensions.getByType<BaseConfiguration>()
+            setProjectVersion(extension.version)
+            setProjectGroup(extension.group, Type.LIBRARY)
             collectUnitTest()
-            setUpPublishing("mavenTalaiotLib", null)
+            setUpPublishing(Type.LIBRARY)
+            setUpJfrog()
         }
 
         target.dependencies {

--- a/buildSrc/src/main/kotlin/com/talaiot/buildplugins/TalaiotPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/talaiot/buildplugins/TalaiotPlugin.kt
@@ -32,19 +32,18 @@ class TalaiotPlugin : Plugin<Project> {
         target.setUpJunitPlatform()
 
         target.afterEvaluate {
-            val extension = extensions.getByType<TalaiotPluginConfiguration>()
+            val extension = target.extensions.getByType<TalaiotPluginConfiguration>()
             setProjectVersion(extension.version)
-            setProjectGroup(extension.group, Constants.DEFAULT_GROUP_PLUGIN)
-            collectUnitTest()
-            setUpPublishing("mavenTalaiot", extension.artifact)
+            setProjectGroup(extension.group, Type.PLUGIN)
             setUpGradlePublishing()
+            setUpPublishing(Type.PLUGIN)
+            collectUnitTest()
         }
 
         target.dependencies {
             add("testImplementation", "com.nhaarman.mockitokotlin2:mockito-kotlin:2.0.0-RC1")
             add("testImplementation", "io.kotlintest:kotlintest-runner-junit5:3.3.2")
         }
-
     }
 }
 

--- a/buildSrc/src/main/kotlin/com/talaiot/buildplugins/TalaiotPluginConfiguration.kt
+++ b/buildSrc/src/main/kotlin/com/talaiot/buildplugins/TalaiotPluginConfiguration.kt
@@ -1,6 +1,7 @@
 package com.talaiot.buildplugins
 
 import org.gradle.plugin.devel.GradlePluginDevelopmentExtension
+import com.gradle.publish.PluginBundleExtension
 
 /**
  * Plugin Extension to configure a [TalaiotPlugin]
@@ -24,13 +25,12 @@ open class TalaiotPluginConfiguration : BaseConfiguration() {
     var idPlugin: String? = null
 
     /**
-     *  Deployment for snapshots/maven local requires inform about the artifact coordinates of the
-     *  new artifact
-     */
-    var artifact: String? = null
-
-    /**
      * Main Class of the plugin, required by the [GradlePluginDevelopmentExtension]
      */
     var mainClass: String? = null
+
+    /**
+     * Display Name property for the plugin [PluginBundleExtension]]
+     */
+    var displayName: String? = null
 }

--- a/buildSrc/src/test/kotlin/com/talaiot/buildplugins/TalaiotPluginTest.kt
+++ b/buildSrc/src/test/kotlin/com/talaiot/buildplugins/TalaiotPluginTest.kt
@@ -90,7 +90,7 @@ class TalaiotPluginTest {
             buildGradleWithTalaiotAndCustomRepositoryNoVersion(rootFolder.absolutePath).trimIndent()
         )
 
-        buildResult(rootFolder, "publishMavenTalaiotPublicationToTestRepo")
+        buildResult(rootFolder, "publishTalaiotLibPublicationToTestRepo")
 
         assert(
             File("${rootFolder.absoluteFile}/repo/com/cdsap/talaiot//${Constants.TALAIOT_VERSION}")
@@ -109,7 +109,7 @@ class TalaiotPluginTest {
             buildGradleWithTalaiotAndCustomRepositoryNoGroup(rootFolder.absolutePath).trimIndent()
         )
 
-        buildResult(rootFolder, "publishMavenTalaiotPublicationToTestRepo")
+        buildResult(rootFolder, "publishTalaiotLibPublicationToTestRepo")
 
         assert(
             File("${rootFolder.absoluteFile}/repo/com/cdsap/talaiot/plugin/talaiot/${Constants.TALAIOT_VERSION}")
@@ -127,7 +127,7 @@ class TalaiotPluginTest {
             buildGradleWithTalaiotAndCustomRepositoryAndVerionGroup(rootFolder.absolutePath).trimIndent()
         )
 
-        buildResult(rootFolder, "publishMavenTalaiotPublicationToTestRepo")
+        buildResult(rootFolder, "publishTalaiotLibPublicationToTestRepo")
 
         assert(File("${rootFolder.absoluteFile}/repo/com/cdsap/overridegroup/talaiot/1.3.6/talaiot-1.3.6.jar").exists())
         rootFolder.deleteRecursively()

--- a/library/core/talaiot-logger/build.gradle.kts
+++ b/library/core/talaiot-logger/build.gradle.kts
@@ -1,3 +1,9 @@
 plugins {
     id("kotlinLib")
 }
+
+talaiotLib{
+    artifact = "talaiot-logger"
+    group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
+    version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+}

--- a/library/core/talaiot-logger/build.gradle.kts
+++ b/library/core/talaiot-logger/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("kotlinLib")
 }
 
-talaiotLib{
+talaiotLib {
     artifact = "talaiot-logger"
     group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
     version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION

--- a/library/core/talaiot-request/build.gradle.kts
+++ b/library/core/talaiot-request/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("kotlinLib")
 }
-talaiotLib{
+talaiotLib {
     artifact = "talaiot-request"
     group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
     version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION

--- a/library/core/talaiot-request/build.gradle.kts
+++ b/library/core/talaiot-request/build.gradle.kts
@@ -1,6 +1,11 @@
 plugins {
     id("kotlinLib")
 }
+talaiotLib{
+    artifact = "talaiot-request"
+    group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
+    version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+}
 
 dependencies {
     api(project(":library:core:talaiot-logger"))

--- a/library/core/talaiot-test-utils/build.gradle.kts
+++ b/library/core/talaiot-test-utils/build.gradle.kts
@@ -2,6 +2,12 @@ plugins {
     id("kotlinLib")
 }
 
+talaiotLib{
+    artifact = "talaiot-test-utils"
+    group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
+    version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+}
+
 dependencies {
     implementation(project(":library:core:talaiot-logger"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.3.72")

--- a/library/core/talaiot-test-utils/build.gradle.kts
+++ b/library/core/talaiot-test-utils/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("kotlinLib")
 }
 
-talaiotLib{
+talaiotLib {
     artifact = "talaiot-test-utils"
     group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
     version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION

--- a/library/core/talaiot/build.gradle.kts
+++ b/library/core/talaiot/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     `kotlin-dsl`
 }
 
-talaiotLib{
+talaiotLib {
     artifact = "talaiot"
     group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
     version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION

--- a/library/core/talaiot/build.gradle.kts
+++ b/library/core/talaiot/build.gradle.kts
@@ -4,6 +4,12 @@ plugins {
     `kotlin-dsl`
 }
 
+talaiotLib{
+    artifact = "talaiot"
+    group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
+    version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+}
+
 dependencies {
     api(project(":library:core:talaiot-logger"))
     api(project(":library:core:talaiot-request"))

--- a/library/plugins/base/base-plugin/build.gradle.kts
+++ b/library/plugins/base/base-plugin/build.gradle.kts
@@ -5,9 +5,10 @@ plugins {
 talaiotPlugin {
     idPlugin = "com.cdsap.talaiot.plugin.base"
     artifact = "base"
-    group = "com.cdsap.talaiot.plugin"
+    group =  com.talaiot.buildplugins.Constants.DEFAULT_GROUP_PLUGIN
     mainClass = "com.cdsap.talaiot.plugin.base.TalaiotBasePlugin"
-    version = "1.3.6-SNAPSHOT"
+    version =  com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+    displayName = "Talaiot, Base Plugin"
 }
 
 dependencies {
@@ -15,4 +16,3 @@ dependencies {
     implementation(project(":library:core:talaiot"))
     testImplementation(project(":library:core:talaiot-test-utils"))
 }
-

--- a/library/plugins/base/base-plugin/src/main/java/com/cdsap/talaiot/plugin/base/BaseExtension.kt
+++ b/library/plugins/base/base-plugin/src/main/java/com/cdsap/talaiot/plugin/base/BaseExtension.kt
@@ -1,9 +1,6 @@
 package com.cdsap.talaiot.plugin.base
 
-
-
 import com.cdsap.talaiot.TalaiotExtension
-import com.cdsap.talaiot.publisher.PublishersConfiguration
 import groovy.lang.Closure
 import org.gradle.api.Project
 
@@ -13,7 +10,7 @@ open class BaseExtension(project: Project) : TalaiotExtension(project) {
      */
     var publishers: BaseConfiguration? = null
 
-    fun publishers(block: PublishersConfiguration.() -> Unit) {
+    fun publishers(block: BaseConfiguration.() -> Unit) {
         publishers = BaseConfiguration(project).also(block)
     }
 

--- a/library/plugins/base/base-publisher/build.gradle.kts
+++ b/library/plugins/base/base-publisher/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("kotlinLib")
 }
 
-talaiotLib{
+talaiotLib {
     artifact = "base-publisher"
     group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
     version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION

--- a/library/plugins/base/base-publisher/build.gradle.kts
+++ b/library/plugins/base/base-publisher/build.gradle.kts
@@ -2,6 +2,12 @@ plugins {
     id("kotlinLib")
 }
 
+talaiotLib{
+    artifact = "base-publisher"
+    group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
+    version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+}
+
 dependencies {
     implementation("com.google.code.gson:gson:2.8.5")
     implementation(project(":library:core:talaiot"))

--- a/library/plugins/elastic-search/elastic-search-plugin/build.gradle.kts
+++ b/library/plugins/elastic-search/elastic-search-plugin/build.gradle.kts
@@ -5,9 +5,10 @@ plugins {
 talaiotPlugin {
     idPlugin = "com.cdsap.talaiot.plugin.elasticsearch"
     artifact = "elasticsearch"
-    group = "com.cdsap.talaiot.plugin"
+    group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_PLUGIN
     mainClass = "com.cdsap.talaiot.plugin.elasticsearch.TalaiotElasticSearchPlugin"
-    version = "1.3.6-SNAPSHOT"
+    version =  com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+    displayName = "Talaiot, Elastic Search Plugin"
 }
 
 dependencies {

--- a/library/plugins/elastic-search/elastic-search-plugin/src/main/kotlin/com/cdsap/talaiot/plugin/elasticsearch/ElasticSearchExtension.kt
+++ b/library/plugins/elastic-search/elastic-search-plugin/src/main/kotlin/com/cdsap/talaiot/plugin/elasticsearch/ElasticSearchExtension.kt
@@ -1,7 +1,6 @@
 package com.cdsap.talaiot.plugin.elasticsearch
 
 import com.cdsap.talaiot.TalaiotExtension
-import com.cdsap.talaiot.publisher.PublishersConfiguration
 import groovy.lang.Closure
 import org.gradle.api.Project
 
@@ -11,7 +10,7 @@ open class ElasticSearchExtension(project: Project) : TalaiotExtension(project) 
      */
     var publishers: ElasticSearchConfiguration? = null
 
-    fun publishers(block: PublishersConfiguration.() -> Unit) {
+    fun publishers(block: ElasticSearchConfiguration.() -> Unit) {
         publishers = ElasticSearchConfiguration(project).also(block)
     }
 

--- a/library/plugins/elastic-search/elastic-search-publisher/build.gradle.kts
+++ b/library/plugins/elastic-search/elastic-search-publisher/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("kotlinLib")
 }
 
-talaiotLib{
+talaiotLib {
     artifact = "elastic-search-publisher"
     group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
     version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION

--- a/library/plugins/elastic-search/elastic-search-publisher/build.gradle.kts
+++ b/library/plugins/elastic-search/elastic-search-publisher/build.gradle.kts
@@ -2,6 +2,12 @@ plugins {
     id("kotlinLib")
 }
 
+talaiotLib{
+    artifact = "elastic-search-publisher"
+    group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
+    version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+}
+
 dependencies {
     implementation(project(":library:core:talaiot"))
     implementation("org.elasticsearch.client:elasticsearch-rest-high-level-client:7.3.0")

--- a/library/plugins/graph/graph-plugin/build.gradle.kts
+++ b/library/plugins/graph/graph-plugin/build.gradle.kts
@@ -5,9 +5,10 @@ plugins {
 talaiotPlugin {
     idPlugin = "com.cdsap.talaiot.plugin.graph"
     artifact = "graph"
-    group = "com.cdsap.talaiot.plugin"
+    group =  com.talaiot.buildplugins.Constants.DEFAULT_GROUP_PLUGIN
     mainClass = "com.cdsap.talaiot.plugin.graph.TalaiotGraphPlugin"
-    version = "1.3.6-SNAPSHOT"
+    version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+    displayName = "Talaiot, Graph Plugin"
 }
 
 dependencies {

--- a/library/plugins/graph/graph-plugin/src/main/java/com/cdsap/talaiot/plugin/graph/GraphExtension.kt
+++ b/library/plugins/graph/graph-plugin/src/main/java/com/cdsap/talaiot/plugin/graph/GraphExtension.kt
@@ -1,7 +1,6 @@
 package com.cdsap.talaiot.plugin.graph
 
 import com.cdsap.talaiot.TalaiotExtension
-import com.cdsap.talaiot.publisher.PublishersConfiguration
 import groovy.lang.Closure
 import org.gradle.api.Project
 
@@ -11,7 +10,7 @@ open class GraphExtension(project: Project) : TalaiotExtension(project) {
      */
     internal var publishers: GraphConfiguration? = null
 
-    fun publishers(block: PublishersConfiguration.() -> Unit) {
+    fun publishers(block: GraphConfiguration.() -> Unit) {
         publishers = GraphConfiguration(project).also(block)
     }
 

--- a/library/plugins/graph/graph-publisher/build.gradle.kts
+++ b/library/plugins/graph/graph-publisher/build.gradle.kts
@@ -3,6 +3,12 @@ plugins {
     `kotlin-dsl`
 }
 
+talaiotLib{
+    artifact = "graph-publisher"
+    group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
+    version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+}
+
 dependencies {
     implementation(project(":library:core:talaiot"))
     implementation("guru.nidi:graphviz-java:0.8.3")

--- a/library/plugins/graph/graph-publisher/build.gradle.kts
+++ b/library/plugins/graph/graph-publisher/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     `kotlin-dsl`
 }
 
-talaiotLib{
+talaiotLib {
     artifact = "graph-publisher"
     group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
     version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION

--- a/library/plugins/hybrid/hybrid-publisher/build.gradle.kts
+++ b/library/plugins/hybrid/hybrid-publisher/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("kotlinLib")
 }
 
-talaiotLib{
+talaiotLib {
     artifact = "hybrid-publisher"
     group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
     version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION

--- a/library/plugins/hybrid/hybrid-publisher/build.gradle.kts
+++ b/library/plugins/hybrid/hybrid-publisher/build.gradle.kts
@@ -2,6 +2,12 @@ plugins {
     id("kotlinLib")
 }
 
+talaiotLib{
+    artifact = "hybrid-publisher"
+    group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
+    version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+}
+
 dependencies {
     implementation(project(":library:core:talaiot"))
     implementation(project(":library:plugins:base:base-publisher"))

--- a/library/plugins/influxdb/influxdb-plugin/build.gradle.kts
+++ b/library/plugins/influxdb/influxdb-plugin/build.gradle.kts
@@ -5,9 +5,10 @@ plugins {
 talaiotPlugin {
     idPlugin = "com.cdsap.talaiot.plugin.influxdb"
     artifact = "influxdb"
-    group = "com.cdsap.talaiot.plugin"
+    group =  com.talaiot.buildplugins.Constants.DEFAULT_GROUP_PLUGIN
     mainClass = "com.cdsap.talaiot.plugin.influxdb.TalaiotInfluxdbPlugin"
-    version = "1.3.6-SNAPSHOT"
+    version =  com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+    displayName = "Talaiot, InfluxDb Plugin"
 }
 
 dependencies {

--- a/library/plugins/influxdb/influxdb-plugin/src/main/kotlin/com/cdsap/talaiot/plugin/influxdb/InfluxdbExtension.kt
+++ b/library/plugins/influxdb/influxdb-plugin/src/main/kotlin/com/cdsap/talaiot/plugin/influxdb/InfluxdbExtension.kt
@@ -1,7 +1,6 @@
 package com.cdsap.talaiot.plugin.influxdb
 
 import com.cdsap.talaiot.TalaiotExtension
-import com.cdsap.talaiot.publisher.PublishersConfiguration
 import groovy.lang.Closure
 import org.gradle.api.Project
 
@@ -11,7 +10,7 @@ open class InfluxdbExtension(project: Project) : TalaiotExtension(project) {
      */
     var publishers: InfluxdbConfiguration? = null
 
-    fun publishers(block: PublishersConfiguration.() -> Unit) {
+    fun publishers(block: InfluxdbConfiguration.() -> Unit) {
         publishers = InfluxdbConfiguration(project).also(block)
     }
 

--- a/library/plugins/influxdb/influxdb-publisher/build.gradle.kts
+++ b/library/plugins/influxdb/influxdb-publisher/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("kotlinLib")
 }
 
-talaiotLib{
+talaiotLib {
     artifact = "influxdb-publisher"
     group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
     version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION

--- a/library/plugins/influxdb/influxdb-publisher/build.gradle.kts
+++ b/library/plugins/influxdb/influxdb-publisher/build.gradle.kts
@@ -2,6 +2,12 @@ plugins {
     id("kotlinLib")
 }
 
+talaiotLib{
+    artifact = "influxdb-publisher"
+    group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
+    version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+}
+
 dependencies {
     implementation(project(":library:core:talaiot"))
     implementation("org.influxdb:influxdb-java:2.19")

--- a/library/plugins/pushgateway/pushgateway-plugin/build.gradle.kts
+++ b/library/plugins/pushgateway/pushgateway-plugin/build.gradle.kts
@@ -5,9 +5,10 @@ plugins {
 talaiotPlugin {
     idPlugin = "com.cdsap.talaiot.plugin.pushgateway"
     artifact = "pushgateway"
-    group = "com.cdsap.talaiot.plugin"
+    group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_PLUGIN
     mainClass = "com.cdsap.talaiot.plugin.pushgateway.TalaiotPushgatewayPlugin"
-    version = "1.3.6-SNAPSHOT"
+    version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+    displayName = "Talaiot, Pushgateway Plugin"
 }
 
 dependencies {

--- a/library/plugins/pushgateway/pushgateway-plugin/src/main/kotlin/com/cdsap/talaiot/plugin/pushgateway/PushgatewayExtension.kt
+++ b/library/plugins/pushgateway/pushgateway-plugin/src/main/kotlin/com/cdsap/talaiot/plugin/pushgateway/PushgatewayExtension.kt
@@ -1,7 +1,6 @@
 package com.cdsap.talaiot.plugin.pushgateway
 
 import com.cdsap.talaiot.TalaiotExtension
-import com.cdsap.talaiot.publisher.PublishersConfiguration
 import groovy.lang.Closure
 import org.gradle.api.Project
 
@@ -11,7 +10,7 @@ open class PushgatewayExtension(project: Project) : TalaiotExtension(project) {
      */
     var publishers: PushgatewayConfiguration? = null
 
-    fun publishers(block: PublishersConfiguration.() -> Unit) {
+    fun publishers(block: PushgatewayConfiguration.() -> Unit) {
         publishers = PushgatewayConfiguration(project).also(block)
     }
 

--- a/library/plugins/pushgateway/pushgateway-publisher/build.gradle.kts
+++ b/library/plugins/pushgateway/pushgateway-publisher/build.gradle.kts
@@ -2,6 +2,12 @@ plugins {
     id("kotlinLib")
 }
 
+talaiotLib{
+    artifact = "pushgateway-publisher"
+    group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
+    version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+}
+
 dependencies {
     implementation(project(":library:core:talaiot"))
     implementation(project(":library:core:talaiot-request"))

--- a/library/plugins/pushgateway/pushgateway-publisher/build.gradle.kts
+++ b/library/plugins/pushgateway/pushgateway-publisher/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("kotlinLib")
 }
 
-talaiotLib{
+talaiotLib {
     artifact = "pushgateway-publisher"
     group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
     version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION

--- a/library/plugins/rethinkdb/rethinkdb-plugin/build.gradle.kts
+++ b/library/plugins/rethinkdb/rethinkdb-plugin/build.gradle.kts
@@ -2,12 +2,14 @@ plugins {
     id("talaiotPlugin")
 }
 
+
 talaiotPlugin {
     idPlugin = "com.cdsap.talaiot.plugin.rethinkdb"
     artifact = "rethinkdb"
-    group = "com.cdsap.talaiot.plugin"
+    group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_PLUGIN
     mainClass = "com.cdsap.talaiot.plugin.rethinkdb.TalaiotRethinkdbPlugin"
-    version = "1.3.6-SNAPSHOT"
+    version =  com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+    displayName = "Talaiot, RethinkDb Plugin"
 }
 
 dependencies {

--- a/library/plugins/rethinkdb/rethinkdb-plugin/src/main/kotlin/com/cdsap/talaiot/plugin/rethinkdb/RethinkdbExtension.kt
+++ b/library/plugins/rethinkdb/rethinkdb-plugin/src/main/kotlin/com/cdsap/talaiot/plugin/rethinkdb/RethinkdbExtension.kt
@@ -11,7 +11,7 @@ open class RethinkdbExtension(project: Project) : TalaiotExtension(project) {
      */
     var publishers: RethinkdbConfiguration? = null
 
-    fun publishers(block: PublishersConfiguration.() -> Unit) {
+    fun publishers(block: RethinkdbConfiguration.() -> Unit) {
         publishers = RethinkdbConfiguration(project).also(block)
     }
 

--- a/library/plugins/rethinkdb/rethinkdb-publisher/build.gradle.kts
+++ b/library/plugins/rethinkdb/rethinkdb-publisher/build.gradle.kts
@@ -2,6 +2,12 @@ plugins {
     id("kotlinLib")
 }
 
+talaiotLib{
+    artifact = "rethinkdb-publisher"
+    group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
+    version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+}
+
 dependencies {
     implementation(project(":library:core:talaiot"))
     implementation("com.rethinkdb:rethinkdb-driver:2.3.3")

--- a/library/plugins/rethinkdb/rethinkdb-publisher/build.gradle.kts
+++ b/library/plugins/rethinkdb/rethinkdb-publisher/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("kotlinLib")
 }
 
-talaiotLib{
+talaiotLib {
     artifact = "rethinkdb-publisher"
     group = com.talaiot.buildplugins.Constants.DEFAULT_GROUP_LIBRARY
     version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION

--- a/library/plugins/talaiot-standard/build.gradle.kts
+++ b/library/plugins/talaiot-standard/build.gradle.kts
@@ -8,7 +8,8 @@ talaiotPlugin {
     artifact = "talaiot"
     group = "com.cdsap"
     mainClass = "com.cdsap.talaiot.plugin.TalaiotPlugin"
-    version = "1.3.6-SNAPSHOT"
+    version = com.talaiot.buildplugins.Constants.TALAIOT_VERSION
+    displayName = "Talaiot"
 }
 
 dependencies {


### PR DESCRIPTION
Fixes for #256 #257 

* @MyDogTom I fixed the problem you mentioned, the Extension for kts for Influx, Base, Graph, Elastic Search was incorrect. Tests were building with Groovy and we were not able to catch the error. 

* Fixed the problem of `mavenPlugin` name artifact, now all the plugins have same id. Plugins redeployed