### PR TITLE
Updating InternalBuildListener

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
       - checkout
       - run:
           name: snapshot
-          command: ./gradlew publishMavenTalaiotLibPublicationToSnapshotsRepository publishMavenTalaiotPublicationToSnapshotsRepository
+          command: ./gradlew publishTalaiotLibPublicationToSnapshotsRepository
 
 workflows:
   version: 2.1

--- a/buildSrc/src/main/kotlin/com/talaiot/buildplugins/Constants.kt
+++ b/buildSrc/src/main/kotlin/com/talaiot/buildplugins/Constants.kt
@@ -1,7 +1,7 @@
 package com.talaiot.buildplugins
 
 object Constants {
-    const val TALAIOT_VERSION = "1.4.0"
+    const val TALAIOT_VERSION = "1.4.1-SNAPSHOT"
     const val DEFAULT_GROUP_PLUGIN = "com.cdsap.talaiot.plugin"
     const val DEFAULT_GROUP_LIBRARY = "com.cdsap.talaiot"
 }

--- a/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/BuildCacheOperationListener.kt
+++ b/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/BuildCacheOperationListener.kt
@@ -12,10 +12,11 @@ import org.gradle.internal.operations.OperationFinishEvent
 import org.gradle.internal.operations.OperationIdentifier
 import org.gradle.internal.operations.OperationProgressEvent
 import org.gradle.internal.operations.OperationStartEvent
+import java.util.concurrent.ConcurrentHashMap
 
 internal class BuildCacheOperationListener : BuildOperationListener, Provider<ExecutedTasksInfo> {
-    private val taskCacheDownloadResults = HashMap<OperationIdentifier, BuildCacheRemoteLoadBuildOperationType.Result>()
-    private val tasksMap = HashMap<OperationIdentifier, TaskExecutionResults>()
+    private val taskCacheDownloadResults = ConcurrentHashMap<OperationIdentifier, BuildCacheRemoteLoadBuildOperationType.Result>()
+    private val tasksMap = ConcurrentHashMap<OperationIdentifier, TaskExecutionResults>()
     override fun get(): ExecutedTasksInfo {
         val tasksList = tasksMap.map { (taskIdentifier, executionResult) ->
             val isCacheEnabled = executionResult.result.cachingDisabledReasonCategory == null

--- a/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/TalaiotListener.kt
+++ b/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/TalaiotListener.kt
@@ -19,6 +19,7 @@ import org.gradle.api.internal.GradleInternal
 import org.gradle.api.invocation.Gradle
 
 import org.gradle.api.tasks.TaskState
+import org.gradle.internal.InternalBuildListener
 import org.gradle.internal.scan.time.BuildScanBuildStartedTime
 import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.invocation.DefaultGradle
@@ -46,7 +47,7 @@ class TalaiotListener(
     private val extension: TalaiotExtension,
     private val tasksInfoProvider: Provider<ExecutedTasksInfo>,
     private val publisherConfigurationProvider: PublisherConfigurationProvider
-) : BuildListener, TaskExecutionListener {
+) : InternalBuildListener, TaskExecutionListener {
 
     private val talaiotTracker = TalaiotTracker()
     private var start: Long = 0L

--- a/library/plugins/talaiot-standard/src/test/kotlin/com/cdsap/talaiot/IntegrationSpec.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/com/cdsap/talaiot/IntegrationSpec.kt
@@ -13,8 +13,7 @@ import java.io.File
 class DefaultConfigurationSpec : StringSpec({
     "given default config" {
         forAll(listOf(
-            "6.7",
-            "6.5",
+            "6.4.1",
             "6.2.1",
             "6.0.1"
         )) { version: String ->

--- a/library/plugins/talaiot-standard/src/test/kotlin/com/cdsap/talaiot/IntegrationSpec.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/com/cdsap/talaiot/IntegrationSpec.kt
@@ -13,15 +13,10 @@ import java.io.File
 class DefaultConfigurationSpec : StringSpec({
     "given default config" {
         forAll(listOf(
-            "6.4.1",
+            "6.7",
+            "6.5",
             "6.2.1",
-            "6.0.1",
-            "5.6.4",
-            "5.5.1",
-            "5.4.1",
-            "5.3.1",
-            "5.2.1",
-            "5.1.1"
+            "6.0.1"
         )) { version: String ->
             val testProjectDir = TemporaryFolder()
 


### PR DESCRIPTION
Build Scan shows warnings when using Builds including Talaiot:
```

The BuildListener.buildStarted(Gradle) method has been deprecated. |  
-- | --
  | This is scheduled to be removed in Gradle 7.0.

```
Updating to InternalBuildListener:
```
public interface InternalBuildListener extends BuildListener, InternalListener {
    /**
     * <p>Called when the build is started.</p>
     *
     * @param gradle The build which is being started. Never null.
     */
    void buildStarted(Gradle gradle);
}
```

Closes #250 