### PR TITLE
changing to ConcurrentHashmap

### DIFF
--- a/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/BuildCacheOperationListener.kt
+++ b/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/BuildCacheOperationListener.kt
@@ -12,10 +12,11 @@ import org.gradle.internal.operations.OperationFinishEvent
 import org.gradle.internal.operations.OperationIdentifier
 import org.gradle.internal.operations.OperationProgressEvent
 import org.gradle.internal.operations.OperationStartEvent
+import java.util.concurrent.ConcurrentHashMap
 
 internal class BuildCacheOperationListener : BuildOperationListener, Provider<ExecutedTasksInfo> {
-    private val taskCacheDownloadResults = HashMap<OperationIdentifier, BuildCacheRemoteLoadBuildOperationType.Result>()
-    private val tasksMap = HashMap<OperationIdentifier, TaskExecutionResults>()
+    private val taskCacheDownloadResults = ConcurrentHashMap<OperationIdentifier, BuildCacheRemoteLoadBuildOperationType.Result>()
+    private val tasksMap = ConcurrentHashMap<OperationIdentifier, TaskExecutionResults>()
     override fun get(): ExecutedTasksInfo {
         val tasksList = tasksMap.map { (taskIdentifier, executionResult) ->
             val isCacheEnabled = executionResult.result.cachingDisabledReasonCategory == null


### PR DESCRIPTION
At work we are still having builds with this error https://github.com/cdsap/Talaiot/issues/192 
Wondering if we can avoid this problem adding thread safe type. 
