### PR TITLE
Compatibility configuration cache

### DIFF
--- a/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/ProjectExtensions.kt
+++ b/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/ProjectExtensions.kt
@@ -1,0 +1,8 @@
+package com.cdsap.talaiot
+
+import org.gradle.api.internal.GradleInternal
+import org.gradle.api.invocation.Gradle
+import org.gradle.internal.operations.BuildOperationListenerManager
+
+internal fun Gradle.buildOperationListenerManager(): BuildOperationListenerManager =
+        (this as GradleInternal).services[BuildOperationListenerManager::class.java]

--- a/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/Talaiot.kt
+++ b/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/Talaiot.kt
@@ -2,10 +2,6 @@ package com.cdsap.talaiot
 
 import com.cdsap.talaiot.provider.PublisherConfigurationProvider
 import org.gradle.api.Project
-import org.gradle.api.internal.GradleInternal
-import org.gradle.api.invocation.Gradle
-import org.gradle.internal.operations.BuildOperationListenerManager
-
 
 /**
  * Talaiot main [Plugin].
@@ -46,9 +42,5 @@ class Talaiot <T : TalaiotExtension>(
         )
         target.gradle.addBuildListener(listener)
         target.gradle.buildOperationListenerManager().addListener(buildOperationListener)
-
     }
-
-    private fun Gradle.buildOperationListenerManager(): BuildOperationListenerManager =
-        (this as GradleInternal).services[BuildOperationListenerManager::class.java]
 }

--- a/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/Talaiot.kt
+++ b/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/Talaiot.kt
@@ -1,6 +1,7 @@
 package com.cdsap.talaiot
 
 import com.cdsap.talaiot.provider.PublisherConfigurationProvider
+import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.invocation.Gradle
@@ -46,9 +47,6 @@ class Talaiot <T : TalaiotExtension>(
         )
         target.gradle.addBuildListener(listener)
         target.gradle.buildOperationListenerManager().addListener(buildOperationListener)
-        target.gradle.buildFinished {
-            target.gradle.buildOperationListenerManager().removeListener(buildOperationListener)
-        }
 
     }
 

--- a/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/Talaiot.kt
+++ b/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/Talaiot.kt
@@ -1,7 +1,6 @@
 package com.cdsap.talaiot
 
 import com.cdsap.talaiot.provider.PublisherConfigurationProvider
-import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.invocation.Gradle

--- a/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/TalaiotListener.kt
+++ b/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/TalaiotListener.kt
@@ -25,7 +25,7 @@ import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.invocation.DefaultGradle
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-
+import org.gradle.internal.operations.BuildOperationListenerManager
 
 /**
  * Custom listener that combines the [BuildListener] and [TaskExecutionListener]. For each [Task] we need to
@@ -57,6 +57,7 @@ class TalaiotListener(
     }
 
     override fun buildFinished(result: BuildResult) {
+        project.gradle.removeListener(tasksInfoProvider)
         if (shouldPublish()) {
             val end = System.currentTimeMillis()
             val logger = LogTrackerImpl(extension.logger)

--- a/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/TalaiotListener.kt
+++ b/library/core/talaiot/src/main/kotlin/com/cdsap/talaiot/TalaiotListener.kt
@@ -25,7 +25,6 @@ import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.invocation.DefaultGradle
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
-import org.gradle.internal.operations.BuildOperationListenerManager
 
 /**
  * Custom listener that combines the [BuildListener] and [TaskExecutionListener]. For each [Task] we need to
@@ -57,7 +56,9 @@ class TalaiotListener(
     }
 
     override fun buildFinished(result: BuildResult) {
-        project.gradle.removeListener(tasksInfoProvider)
+
+        project.gradle.buildOperationListenerManager().removeListener(tasksInfoProvider as BuildCacheOperationListener)
+
         if (shouldPublish()) {
             val end = System.currentTimeMillis()
             val logger = LogTrackerImpl(extension.logger)


### PR DESCRIPTION
Before release 1.4.1 I was testing different versions and currently the project is compatible with AGP 4.2/7.0.
Everything is ok, but still it was not compatible with configuration-cache. 
Removing the `target.gradle.buildFinished` was solving the issue, moved to the buildFinished listener from TalaiotListener. 

I don't think is not very elegant but it solves the issue. Gradle recommends https://docs.gradle.org/6.7.1/userguide/build_services.html#operation_listener but I would need more time to research a bit.

