### PR TITLE
Adding path instead project in publishers

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml
-# Editor-based HTTP Client requests
-/httpRequests/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/library/plugins/base/base-plugin/src/main/java/io/github/cdsap/talaiot/plugin/base/BaseConfigurationProvider.kt
+++ b/library/plugins/base/base-plugin/src/main/java/io/github/cdsap/talaiot/plugin/base/BaseConfigurationProvider.kt
@@ -19,11 +19,11 @@ class BaseConfigurationProvider(
                 publishers.add(OutputPublisher(this, LogTrackerImpl(talaiotExtension.logger)))
             }
             if (jsonPublisher) {
-                publishers.add(JsonPublisher(project.gradle))
+                publishers.add(JsonPublisher(project.gradle.rootProject.buildDir))
             }
 
             if (timelinePublisher) {
-                publishers.add(TimelinePublisher(project.gradle))
+                publishers.add(TimelinePublisher(project.gradle.rootProject.buildDir))
             }
             publishers.addAll(customPublishers)
         }

--- a/library/plugins/base/base-publisher/src/main/java/io/github/cdsap/talaiot/publisher/JsonPublisher.kt
+++ b/library/plugins/base/base-publisher/src/main/java/io/github/cdsap/talaiot/publisher/JsonPublisher.kt
@@ -3,16 +3,15 @@ package io.github.cdsap.talaiot.publisher
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import io.github.cdsap.talaiot.entities.ExecutionReport
-import org.gradle.api.invocation.Gradle
 import java.io.BufferedWriter
 import java.io.File
 import java.io.FileWriter
 
-class JsonPublisher(val gradle: Gradle) : Publisher {
+class JsonPublisher(private val path: File) : Publisher {
     override fun publish(report: ExecutionReport) {
         val gson: Gson = GsonBuilder().setPrettyPrinting().create()
 
-        val file = File(gradle.rootProject.buildDir, "reports/talaiot/json/data.json")
+        val file = File(path, "reports/talaiot/json/data.json")
             .apply {
                 mkdirs()
                 delete()

--- a/library/plugins/base/base-publisher/src/main/java/io/github/cdsap/talaiot/publisher/timeline/TimelinePublisher.kt
+++ b/library/plugins/base/base-publisher/src/main/java/io/github/cdsap/talaiot/publisher/timeline/TimelinePublisher.kt
@@ -4,13 +4,12 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import io.github.cdsap.talaiot.entities.ExecutionReport
 import io.github.cdsap.talaiot.publisher.Publisher
-import org.gradle.api.invocation.Gradle
 import java.io.BufferedWriter
 import java.io.File
 import java.io.FileWriter
 import java.io.InputStream
 
-class TimelinePublisher(val gradle: Gradle) : Publisher {
+class TimelinePublisher(private val path: File) : Publisher {
     override fun publish(report: ExecutionReport) {
         val measures = report.tasks
             ?.filter { !it.rootNode }
@@ -35,7 +34,7 @@ class TimelinePublisher(val gradle: Gradle) : Publisher {
 
         val gson: Gson = GsonBuilder().setPrettyPrinting().create()
 
-        val html = File(gradle.rootProject.buildDir, "reports/talaiot/timeline/index.html")
+        val html = File(path, "reports/talaiot/timeline/index.html")
             .apply {
                 mkdirs()
                 delete()
@@ -59,7 +58,7 @@ class TimelinePublisher(val gradle: Gradle) : Publisher {
         inputStreamFromResources("timeline/chart.css").use {
             it.copyTo(
                 File(
-                    gradle.rootProject.buildDir,
+                    path,
                     "reports/talaiot/timeline/chart.css"
                 ).outputStream()
             )
@@ -67,7 +66,7 @@ class TimelinePublisher(val gradle: Gradle) : Publisher {
         inputStreamFromResources("timeline/chart.js").use {
             it.copyTo(
                 File(
-                    gradle.rootProject.buildDir,
+                    path,
                     "reports/talaiot/timeline/chart.js"
                 ).outputStream()
             )

--- a/library/plugins/talaiot-standard/src/main/kotlin/io/github/cdsap/talaiot/plugin/TalaiotConfigurationProvider.kt
+++ b/library/plugins/talaiot-standard/src/main/kotlin/io/github/cdsap/talaiot/plugin/TalaiotConfigurationProvider.kt
@@ -67,7 +67,7 @@ class TalaiotConfigurationProvider(
             }
 
             if (timelinePublisher) {
-                publishers.add(TimelinePublisher(project.gradle.rootProject.buildDir)))
+                publishers.add(TimelinePublisher(project.gradle.rootProject.buildDir))
             }
 
             elasticSearchPublisher?.apply {

--- a/library/plugins/talaiot-standard/src/main/kotlin/io/github/cdsap/talaiot/plugin/TalaiotConfigurationProvider.kt
+++ b/library/plugins/talaiot-standard/src/main/kotlin/io/github/cdsap/talaiot/plugin/TalaiotConfigurationProvider.kt
@@ -63,11 +63,11 @@ class TalaiotConfigurationProvider(
                 )
             }
             if (jsonPublisher) {
-                publishers.add(JsonPublisher(project.gradle))
+                publishers.add(JsonPublisher(project.gradle.rootProject.buildDir))
             }
 
             if (timelinePublisher) {
-                publishers.add(TimelinePublisher(project.gradle))
+                publishers.add(TimelinePublisher(project.gradle.rootProject.buildDir)))
             }
 
             elasticSearchPublisher?.apply {

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/IntegrationSpec.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/IntegrationSpec.kt
@@ -42,7 +42,7 @@ class DefaultConfigurationSpec : StringSpec({
                     logger = io.github.cdsap.talaiot.logger.LogTracker.Mode.INFO
                     publishers {
                         jsonPublisher = true
-                        customPublishers(new JsonPublisher(getGradle()))
+                        customPublishers(new JsonPublisher(getGradle().rootProject.buildDir))
                     }
                 }
 


### PR DESCRIPTION
Recent issue #313 shows incorrect behavior of Talaiot during build execution with configuration cache. 
Plugin is not failing but the build listeners are not compatible when we hit the conf cache(no reporting). 
In order to start preparing the codebase to Conf Cache, we need to start cleaning types that won't be serialized during the new build service implementation. Additionally, we need to isolate the publishers from the platform