### PR TITLE
Adding configuration cache switch in ExecutionReport

### DIFF
--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/configuration/MetricsConfiguration.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/configuration/MetricsConfiguration.kt
@@ -11,6 +11,7 @@ import io.github.cdsap.talaiot.metrics.GradleRequestedTasksMetric
 import io.github.cdsap.talaiot.metrics.GradleScanLinkMetric
 import io.github.cdsap.talaiot.metrics.GradleSwitchBuildScanMetric
 import io.github.cdsap.talaiot.metrics.GradleSwitchCachingMetric
+import io.github.cdsap.talaiot.metrics.GradleSwitchConfigurationCacheMetric
 import io.github.cdsap.talaiot.metrics.GradleSwitchConfigureOnDemandMetric
 import io.github.cdsap.talaiot.metrics.GradleSwitchDaemonMetric
 import io.github.cdsap.talaiot.metrics.GradleSwitchDryRunMetric
@@ -81,6 +82,7 @@ import io.github.cdsap.talaiot.metrics.base.Metric
  *  [GradleSwitchRefreshDependenciesMetric]
  *  [GradleSwitchRerunTasksMetric]
  *  [GradleSwitchDaemonMetric]
+ *  [GradleSwitchConfigurationCacheMetric]
  *
  * [environmentMetrics] includes:
  *  [OsManufacturerMetric]
@@ -179,6 +181,7 @@ class MetricsConfiguration {
             add(GradleSwitchRefreshDependenciesMetric())
             add(GradleSwitchRerunTasksMetric())
             add(GradleSwitchDaemonMetric())
+            add(GradleSwitchConfigurationCacheMetric())
         }
     }
 

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/entities/ExecutionReport.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/entities/ExecutionReport.kt
@@ -109,7 +109,8 @@ data class Switches(
     var offline: String? = null,
     var rerunTasks: String? = null,
     var refreshDependencies: String? = null,
-    var buildScan: String? = null
+    var buildScan: String? = null,
+    var configurationCache: String? = null
 )
 
 data class CustomProperties(

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/GradleMetrics.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/GradleMetrics.kt
@@ -73,7 +73,7 @@ class GradleSwitchConfigurationCacheMetric : GradleMetric<String?>(
     provider = {
         try {
             (it.gradle.startParameter as StartParameterInternal).configurationCache.get().toString()
-        } catch (e: NoSuchMethodError){
+        } catch (e: NoSuchMethodError) {
             ""
         }
     },

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/GradleMetrics.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/GradleMetrics.kt
@@ -70,7 +70,13 @@ class GradleSwitchDaemonMetric : GradleMetric<String?>(
 )
 
 class GradleSwitchConfigurationCacheMetric : GradleMetric<String?>(
-    provider = { (it.gradle.startParameter as StartParameterInternal).configurationCache.get().toString() },
+    provider = {
+        try {
+            (it.gradle.startParameter as StartParameterInternal).configurationCache.get().toString()
+        } catch (e: NoSuchMethodError){
+            ""
+        }
+    },
     assigner = { report, value -> report.environment.switches.configurationCache = value }
 )
 

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/GradleMetrics.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/GradleMetrics.kt
@@ -5,6 +5,7 @@ import io.github.cdsap.talaiot.metrics.base.GradleMetric
 import io.github.cdsap.talaiot.metrics.base.JvmArgsMetric
 import io.github.cdsap.talaiot.util.TaskAbbreviationMatcher
 import io.github.cdsap.talaiot.util.TaskName
+import org.gradle.api.internal.StartParameterInternal
 import org.gradle.api.internal.project.DefaultProject
 import org.gradle.api.invocation.Gradle
 import org.gradle.launcher.daemon.server.scaninfo.DaemonScanInfo
@@ -66,6 +67,11 @@ class GradleSwitchDaemonMetric : GradleMetric<String?>(
         daemonScanInfo?.isSingleUse?.toString()
     },
     assigner = { report, value -> report.environment.switches.daemon = value }
+)
+
+class GradleSwitchConfigurationCacheMetric : GradleMetric<String?>(
+    provider = { (it.gradle.startParameter as StartParameterInternal).configurationCache.get().toString() },
+    assigner = { report, value -> report.environment.switches.configurationCache = value }
 )
 
 class GradleMaxWorkersMetric : GradleMetric<String>(

--- a/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
+++ b/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
@@ -281,5 +281,6 @@ private val gradleSwitchesMetricsTypes = listOf(
     GradleSwitchDryRunMetric::class,
     GradleSwitchRefreshDependenciesMetric::class,
     GradleSwitchRerunTasksMetric::class,
-    GradleSwitchDaemonMetric::class
+    GradleSwitchDaemonMetric::class,
+    GradleSwitchConfigurationCacheMetric::class
 )

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/GradleSwitchConfigurationCacheTest.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/GradleSwitchConfigurationCacheTest.kt
@@ -1,12 +1,8 @@
 package io.github.cdsap.talaiot
 
-import io.github.cdsap.talaiot.metrics.BuildMetrics
 import io.github.cdsap.talaiot.utils.TemporaryFolder
-import io.kotlintest.Spec
 import io.kotlintest.specs.BehaviorSpec
 import org.gradle.testkit.runner.GradleRunner
-import org.influxdb.dto.Query
-import org.testcontainers.influxdb.KInfluxDBContainer
 import java.io.File
 
 class GradleSwitchConfigurationCacheTest : BehaviorSpec() {

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/GradleSwitchConfigurationCacheTest.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/GradleSwitchConfigurationCacheTest.kt
@@ -1,0 +1,84 @@
+package io.github.cdsap.talaiot
+
+import io.github.cdsap.talaiot.metrics.BuildMetrics
+import io.github.cdsap.talaiot.utils.TemporaryFolder
+import io.kotlintest.Spec
+import io.kotlintest.specs.BehaviorSpec
+import org.gradle.testkit.runner.GradleRunner
+import org.influxdb.dto.Query
+import org.testcontainers.influxdb.KInfluxDBContainer
+import java.io.File
+
+class GradleSwitchConfigurationCacheTest : BehaviorSpec() {
+
+    init {
+        given("Project with plugins Talaiot and Java") {
+
+            val testProjectDir = TemporaryFolder()
+            testProjectDir.create()
+
+            val buildFile = testProjectDir.newFile("build.gradle")
+            buildGradle(buildFile)
+
+            `when`("build executes assemble with JsonPublisher and configuration cache") {
+
+                GradleRunner.create()
+                    .withProjectDir(testProjectDir.getRoot())
+                    .withArguments("assemble", "--configuration-cache")
+                    .withPluginClasspath()
+                    .build()
+
+                then("Configuration Cache switch is registered") {
+                    val file = File("${testProjectDir.getRoot()}/build/reports/talaiot/json/data.json")
+                    assert(file.readText().contains("\"configurationCache\": \"true\""))
+                }
+            }
+            `when`("build executes assemble with JsonPublisher without Configuration cache") {
+
+                GradleRunner.create()
+                    .withProjectDir(testProjectDir.getRoot())
+                    .withArguments("assemble")
+                    .withPluginClasspath()
+                    .build()
+
+                then("Configuration Cache switch is false") {
+                    val file = File("${testProjectDir.getRoot()}/build/reports/talaiot/json/data.json")
+                    assert(file.readText().contains("\"configurationCache\": \"false\""))
+                }
+            }
+            `when`("build executes assemble with JsonPublisher with Gradle < 7.1") {
+
+                GradleRunner.create()
+                    .withProjectDir(testProjectDir.getRoot())
+                    .withArguments("assemble")
+                    .withPluginClasspath()
+                    .withGradleVersion("7.0.2")
+                    .build()
+
+                then("Configuration Cache switch is not registered") {
+                    val file = File("${testProjectDir.getRoot()}/build/reports/talaiot/json/data.json")
+                    assert(file.readText().contains("\"configurationCache\": \"\""))
+                }
+            }
+            testProjectDir.delete()
+        }
+    }
+
+    private fun buildGradle(buildFile: File) {
+        buildFile.appendText(
+            """
+                       plugins {
+                          id 'java'
+                          id 'io.github.cdsap.talaiot'
+                      }
+                      
+                      
+                      talaiot {
+                        publishers {
+                          jsonPublisher = true
+                        }
+                      }  
+            """.trimIndent()
+        )
+    }
+}


### PR DESCRIPTION
Adding the Gradle switch for the new property `configurationCache`.
Fetching the value with:
```
it.gradle.startParameter as StartParameterInternal).configurationCache.get()
```
(thanks Zack)

Property is available since 7.1, returning an empty value from previous Gradle Versions.