### PR TITLE
Update image CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ executor: machine
 jobs:
   build:
     machine:
-      image: circleci/classic:latest
+      image: ubuntu-2004:202201-02
 
     working_directory: ~/repo
 


### PR DESCRIPTION
Switching supported CircleCi Image https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/#switching-to-a-supported-image 
Closes #326