### PR TITLE
Update ci conf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,19 +5,25 @@ executor: machine
 jobs:
   build:
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:edge
 
     working_directory: ~/repo
 
     environment:
-      JVM_OPTS: -Xmx5G
+      JVM_OPTS: -Xmx12G
       TERM: dumb
 
     steps:
       - checkout
       - run:
-          name: build
-          command: ./gradlew ktlintCheck assemble collectUnitTest jacocoTestReport --stacktrace --info
+          name: style
+          command: ./gradlew ktlintCheck
+      - run:
+          name: assemble
+          command: ./gradlew assemble
+      - run:
+          name: test
+          command: ./gradlew collectUnitTest jacocoTestReport --stacktrace --info
       - run:
           name: build sample
           command: |

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx4G
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
In parallel efforts, I noticed the Gradle daemon was killed the docker instance in CI. This happened on high memory pressure scenarios(Main integration test). Extending the default parameters of the project and updating CI conf