### PR TITLE
adding configuration set only in the build publisher

### DIFF
--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/TalaiotBuildService.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/TalaiotBuildService.kt
@@ -48,13 +48,17 @@ abstract class TalaiotBuildService :
     }
 
     override fun close() {
+
         val executor = Executors.newSingleThreadExecutor()
+        val end = System.currentTimeMillis()
+
         executor.execute {
             parameters.publisher.get().publish(
                 taskLengthList = taskLengthList,
                 start = start,
                 configuraionMs = configurationTime,
-                end = System.currentTimeMillis(),
+                end = end,
+                duration = end - start,
                 success = taskLengthList.none { it.state == TaskMessageState.FAILED }
             )
         }
@@ -62,7 +66,7 @@ abstract class TalaiotBuildService :
 
     override fun onFinish(event: FinishEvent?) {
         if (!configurationIsSet) {
-            configurationTime = start - System.currentTimeMillis()
+            configurationTime = System.currentTimeMillis() - start
             configurationIsSet = true
         }
         val duration = event?.result?.endTime!! - event.result?.startTime!!

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisher.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisher.kt
@@ -12,6 +12,7 @@ interface TalaiotPublisher : java.io.Serializable {
         start: Long,
         configuraionMs: Long?,
         end: Long,
-        success: Boolean
+        success: Boolean,
+        duration: Long
     )
 }

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisherImpl.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisherImpl.kt
@@ -26,20 +26,16 @@ class TalaiotPublisherImpl(
         start: Long,
         configuraionMs: Long?,
         end: Long,
-        success: Boolean
+        success: Boolean,
+        duration: Long
     ) {
         executionReport.tasks = taskLengthList.filter { taskFilterProcessor.taskLengthFilter(it) }
         executionReport.unfilteredTasks = taskLengthList
         executionReport.beginMs = start.toString()
         executionReport.endMs = end.toString()
         executionReport.success = success
-
-        executionReport.durationMs = (end - start).toString()
-
-        executionReport.configurationDurationMs = when {
-            configuraionMs != null -> (configuraionMs - start).toString()
-            else -> "undefined"
-        }
+        executionReport.durationMs = duration.toString()
+        executionReport.configurationDurationMs = configuraionMs.toString()
 
         if (buildFilterProcessor.shouldPublishBuild(executionReport)) {
             publisherProvider.forEach {

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/TalaiotPublisherImplTest.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/TalaiotPublisherImplTest.kt
@@ -48,7 +48,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, executionReport, publishers.get()
             ).publish(
-                mutableListOf(getSingleTask()), 0, 100, 200, true
+                mutableListOf(getSingleTask()), 0, 100, 200, true, 200
             )
             then("outputPublisher is publishing one task result ") {
                 assert(publishers.get().size == 1)
@@ -78,7 +78,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, executionReport, publishers.get()
             ).publish(
-                getTasks(), 0, 100, 200, true
+                getTasks(), 0, 100, 200, true, 200
             )
 
             then("two publishers are processed ") {
@@ -120,7 +120,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, executionReport, publishers.get()
             ).publish(
-                getTasks(), 0, 100, 200, true
+                getTasks(), 0, 100, 200, true, 200
             )
 
             then("two publishers are processed and one task has been filtered ") {
@@ -164,7 +164,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, executionReport, publishers.get()
             ).publish(
-                getTasks(), 0, 100, 200, true
+                getTasks(), 0, 100, 200, true, 200
             )
 
             then("two publishers are processed and one task has been filtered ") {
@@ -198,7 +198,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, executionReport, publishers.get()
             ).publish(
-                getTasks(), 0, 100, 200, true
+                getTasks(), 0, 100, 200, true, 200
             )
 
             then("successful build is published") {
@@ -227,7 +227,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, executionReport, publishers.get()
             ).publish(
-                getTasks(), 0, 100, 200, false
+                getTasks(), 0, 100, 200, false, 200
             )
 
             then("failed build is not published") {
@@ -256,7 +256,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, executionReport, publishers.get()
             ).publish(
-                getTasks(), 0, 100, 200, false
+                getTasks(), 0, 100, 200, false, 200
             )
 
             then("build with a different task is published") {
@@ -283,7 +283,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, report, publishers.get()
             ).publish(
-                taskLengthList = getTasks(), start = 0, configuraionMs = 100, end = 200, success = true
+                taskLengthList = getTasks(), start = 0, configuraionMs = 100, end = 200, success = true, duration = 200
             )
             then("no information is published") {
                 verifyZeroInteractions(publishers.get()[0])
@@ -310,7 +310,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, report, publishers.get()
             ).publish(
-                taskLengthList = getTasks(), start = 0, configuraionMs = 100, end = 200, success = false
+                taskLengthList = getTasks(), start = 0, configuraionMs = 100, end = 200, success = false, duration = 200
             )
             then("build with a different task is not published") {
 
@@ -337,7 +337,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, report, publishers.get()
             ).publish(
-                taskLengthList = getTasks(), start = 0, configuraionMs = 100, end = 200, success = true
+                taskLengthList = getTasks(), start = 0, configuraionMs = 100, end = 200, success = true, duration = 200
             )
             then("build with the same task is published") {
                 verify(publishers.get()[0]).publish(any())
@@ -366,7 +366,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, report, publishers.get()
             ).publish(
-                taskLengthList = getTasks(), start = 0, configuraionMs = 100, end = 200, success = true
+                taskLengthList = getTasks(), start = 0, configuraionMs = 100, end = 200, success = true, duration = 200
             )
 
             then("build with at least one task included is published") {
@@ -396,7 +396,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, report, publishers.get()
             ).publish(
-                taskLengthList = getTasks(), start = 0, configuraionMs = 100, end = 200, success = true
+                taskLengthList = getTasks(), start = 0, configuraionMs = 100, end = 200, success = true, duration = 200
             )
 
             then("build with all tasks filtered out is not published") {
@@ -429,7 +429,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             )
 
             publisher.publish(
-                mutableListOf(getSingleTask("a"), getSingleTask("b"), getSingleTask("c")), 0, 100, 200, true
+                mutableListOf(getSingleTask("a"), getSingleTask("b"), getSingleTask("c")), 0, 100, 200, true, 200
             )
             then("should publish cache information for each task") {
                 val reportCaptor = argumentCaptor<ExecutionReport>()


### PR DESCRIPTION
We were keeping the configuration in the publisher implementation:
```
 executionReport.configurationDurationMs = when {
            configuraionMs != null -> (configuraionMs - start).toString()
            else -> "undefined"
        }
```
this pr removed the conf