### PR TITLE
Use ValueSource for GitMetrics

### DIFF
--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/base/CmdMetric.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/base/CmdMetric.kt
@@ -1,25 +1,20 @@
 package io.github.cdsap.talaiot.metrics.base
 
 import io.github.cdsap.talaiot.entities.ExecutionReport
-import io.github.cdsap.talaiot.metrics.SimpleMetric
-import java.io.BufferedReader
-import java.io.InputStreamReader
-import java.lang.IllegalStateException
 
 /**
  * [Metric] that operates on some command line action output
  */
-open class CmdMetric(val cmd: String, assigner: (ExecutionReport, String) -> Unit) : SimpleMetric<String>(
-    provider = {
-        val runtime = Runtime.getRuntime()
+open class CmdMetric(val cmd: String, assigner: (ExecutionReport, String) -> Unit) : GradleMetric<String>(
+    provider = { project ->
         try {
-            val reader = BufferedReader(
-                InputStreamReader(runtime.exec(cmd).inputStream)
-            )
-            val result = reader.readLine()
-            result ?: "undefined"
+            project.providers.exec { spec ->
+                spec.commandLine(cmd.split(" "))
+            }.standardOutput.asText.get().trim()
         } catch (e: IllegalStateException) {
-            throw IllegalArgumentException("Error executing $cmd. Consider disabling the metric from your configuration", e)
+            throw IllegalArgumentException(
+                "Error executing $cmd. Consider disabling the metric from your configuration", e
+            )
         }
     },
     assigner = assigner


### PR DESCRIPTION
The current way of evaluating these metrics is incompatible with configuration cache. See [here](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:external_processes)