### PR TITLE
differenciate execution from duration

### DIFF
--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/TalaiotBuildService.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/TalaiotBuildService.kt
@@ -77,7 +77,7 @@ abstract class TalaiotBuildService :
         parameters.publisher.get().publish(
             taskLengthList = taskLengthList,
             start = start,
-            configuraionMs = configurationTime,
+            configuration = configurationTime,
             end = end,
             duration = end - start,
             success = taskLengthList.none {

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/entities/ExecutionReport.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/entities/ExecutionReport.kt
@@ -30,6 +30,7 @@ data class ExecutionReport(
     var endMs: String? = null,
     var durationMs: String? = null,
     var configurationDurationMs: String? = null,
+    var executionDurationMs: String? = null,
     var tasks: List<TaskLength>? = null,
     var unfilteredTasks: List<TaskLength>? = null,
     var buildId: String? = null,

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisher.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisher.kt
@@ -10,7 +10,7 @@ interface TalaiotPublisher : java.io.Serializable {
     fun publish(
         taskLengthList: MutableList<TaskLength>,
         start: Long,
-        configuraionMs: Long?,
+        configuration: Long,
         end: Long,
         success: Boolean,
         duration: Long,

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisherImpl.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisherImpl.kt
@@ -23,7 +23,7 @@ class TalaiotPublisherImpl(
     override fun publish(
         taskLengthList: MutableList<TaskLength>,
         start: Long,
-        configuraionMs: Long?,
+        configuration: Long,
         end: Long,
         success: Boolean,
         duration: Long,
@@ -35,8 +35,9 @@ class TalaiotPublisherImpl(
         executionReport.beginMs = start.toString()
         executionReport.endMs = end.toString()
         executionReport.success = success
-        executionReport.durationMs = duration.toString()
-        executionReport.configurationDurationMs = configuraionMs.toString()
+        executionReport.executionDurationMs = duration.toString()
+        executionReport.durationMs = (duration + configuration).toString()
+        executionReport.configurationDurationMs = configuration.toString()
         executionReport.configurationCacheHit = configurationCacheHit
 
         if (buildFilterProcessor.shouldPublishBuild(executionReport)) {

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/TalaiotPublisherImplTest.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/TalaiotPublisherImplTest.kt
@@ -284,7 +284,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, report
             ).publish(
-                taskLengthList = getTasks(), start = 0, configuraionMs = 100, end = 200, success = true, duration = 200,
+                taskLengthList = getTasks(), start = 0, configuration = 100, end = 200, success = true, duration = 200,
                 publishers.get(), true
             )
             then("no information is published") {
@@ -314,7 +314,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             ).publish(
                 taskLengthList = getTasks(),
                 start = 0,
-                configuraionMs = 100,
+                configuration = 100,
                 end = 200,
                 success = false,
                 duration = 200,
@@ -346,7 +346,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, report
             ).publish(
-                taskLengthList = getTasks(), start = 0, configuraionMs = 100, end = 200, success = true, duration = 200,
+                taskLengthList = getTasks(), start = 0, configuration = 100, end = 200, success = true, duration = 200,
                 publishers.get(), true
             )
             then("build with the same task is published") {
@@ -376,7 +376,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, report
             ).publish(
-                taskLengthList = getTasks(), start = 0, configuraionMs = 100, end = 200, success = true, duration = 200,
+                taskLengthList = getTasks(), start = 0, configuration = 100, end = 200, success = true, duration = 200,
                 publishers.get(), true
             )
 
@@ -407,7 +407,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
             talaiotPublisherImpl(
                 extension, logger, project, report
             ).publish(
-                taskLengthList = getTasks(), start = 0, configuraionMs = 100, end = 200, success = true, duration = 200,
+                taskLengthList = getTasks(), start = 0, configuration = 100, end = 200, success = true, duration = 200,
                 publishers.get(), true
             )
 
@@ -469,6 +469,37 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                     )
                 )
                 reportCaptor.firstValue.tasks.shouldBe(expectedTasks)
+            }
+        }
+        `when`("execution duration is different from build duration") {
+            val project: Project = mock()
+            val extension = TalaiotPluginExtension(project).apply {
+                filter {
+                    build {
+                        success = true
+                    }
+                }
+                publishers {
+                    jsonPublisher = true
+                }
+            }
+            setUpMockExtension(project, extension)
+
+            val executionReport = ExecutionReport()
+            val publishers: PublisherConfigurationProvider = mock()
+            val jsonPublisher: Publisher = mock()
+            whenever(publishers.get()).thenReturn(listOf(jsonPublisher))
+            talaiotPublisherImpl(
+                extension, logger, project, executionReport
+            ).publish(
+                getTasks(), 0, 100, 200, true, 200, publishers.get(), true
+            )
+
+            then("duration is the sum of execution and configuration") {
+                val reportCaptor = argumentCaptor<ExecutionReport>()
+                verify(publishers.get()[0]).publish(reportCaptor.capture())
+                reportCaptor.firstValue.executionDurationMs.shouldBe("200")
+                reportCaptor.firstValue.durationMs.shouldBe("300")
             }
         }
     }


### PR DESCRIPTION
The duration of `ExeccutionReport` was considering only the overall task execution. 
This PR adds the configuration time to the `durationMs` property and adds new field `executionDurationMs` representing the duration of the execution time