### PR TITLE
Identifying task skipped event

### DIFF
--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/TalaiotBuildService.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/TalaiotBuildService.kt
@@ -109,6 +109,7 @@ abstract class TalaiotBuildService :
                     "UP-TO-DATE" -> TaskMessageState.UP_TO_DATE
                     "FROM-CACHE" -> TaskMessageState.FROM_CACHE
                     "NO-SOURCE" -> TaskMessageState.NO_SOURCE
+                    "skipped" -> TaskMessageState.SKIPPED
                     "failed" -> TaskMessageState.FAILED
                     else -> TaskMessageState.EXECUTED
                 },

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/entities/TaskMessageState.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/entities/TaskMessageState.kt
@@ -10,5 +10,6 @@ enum class TaskMessageState {
     NO_SOURCE,
     UP_TO_DATE,
     EXECUTED,
-    FAILED
+    FAILED,
+    SKIPPED
 }

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/DefaultConfigurationSpec.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/DefaultConfigurationSpec.kt
@@ -2,6 +2,7 @@ package io.github.cdsap.talaiot
 
 import com.google.gson.Gson
 import io.github.cdsap.talaiot.entities.ExecutionReport
+import io.github.cdsap.talaiot.entities.TaskMessageState
 import io.github.cdsap.talaiot.utils.TemporaryFolder
 import io.kotlintest.forAll
 import io.kotlintest.shouldBe

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/DefaultConfigurationSpec.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/DefaultConfigurationSpec.kt
@@ -70,7 +70,7 @@ class DefaultConfigurationSpec : StringSpec({
             val tasks = report.tasks!!
             tasks.size shouldBe 5
             tasks.count { it.rootNode } shouldBe 1
-
+            tasks.first { it.taskName.contains("processResources") }.state shouldBe TaskMessageState.SKIPPED
             tasks.find { it.rootNode }!!.taskName shouldBe "assemble"
 
             report.requestedTasks shouldBe "assemble"


### PR DESCRIPTION
The event received when one task has the state:
```
> Task :compileJava NO-SOURCE
```
is:
```
Task :compileJava skipped
```
At the `TalaiotBuildService` we don't have access to the project to check the state of the task to determine if the reason is `NO-SOURCE`.  This PR addresses the potential issue adding a new Talaiot TaskMessageState called SKIPPED