### PR TITLE
chore: remove unused `TalaiotBuildService` code

### DIFF
--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/TalaiotBuildService.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/TalaiotBuildService.kt
@@ -26,8 +26,6 @@ abstract class TalaiotBuildService :
     OperationCompletionListener {
 
     var start = 0L
-    private var configurationTime = 0L
-    private var configurationIsSet = false
 
     interface Params : BuildServiceParameters {
         /**
@@ -88,10 +86,6 @@ abstract class TalaiotBuildService :
     }
 
     override fun onFinish(event: FinishEvent?) {
-        if (!configurationIsSet) {
-            configurationTime = System.currentTimeMillis() - start
-            configurationIsSet = true
-        }
         val duration = event?.result?.endTime!! - event.result?.startTime!!
         val end = event.result?.endTime!!
         val start = event.result?.startTime!!


### PR DESCRIPTION
While reading the Talaiot source code, I've spotted an unused fragment of code. This small PR removes the unused part.