### PR TITLE
Processes in environments and type in tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       image: 'ubuntu-2004:2023.02.1'
     working_directory: ~/repo
     environment:
-      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx8G -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport" -Dorg.gradle.parallel=true -Dorg.gradle.daemon=false
+      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx8G -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport" -Dorg.gradle.parallel=false -Dorg.gradle.daemon=false
       TERM: dumb
     steps:
       - checkout

--- a/library/core/talaiot/build.gradle.kts
+++ b/library/core/talaiot/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     api(project(":library:core:talaiot-logger"))
     api(project(":library:core:talaiot-request"))
     implementation("io.github.cdsap:commandline-value-source:0.1.0")
+    implementation("io.github.cdsap:jdk-tools-parser:0.1.1")
     testImplementation("io.github.rybalkinsd:kohttp:0.10.0")
     testImplementation(project(":library:core:talaiot-test-utils"))
 }

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/configuration/MetricsConfiguration.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/configuration/MetricsConfiguration.kt
@@ -6,12 +6,12 @@ import io.github.cdsap.talaiot.metrics.DefaultCharsetMetric
 import io.github.cdsap.talaiot.metrics.GitBranchMetric
 import io.github.cdsap.talaiot.metrics.GitUserMetric
 import io.github.cdsap.talaiot.metrics.GradleMaxWorkersMetric
+import io.github.cdsap.talaiot.metrics.GradleProcessMetrics
 import io.github.cdsap.talaiot.metrics.GradleRequestedTasksMetric
 import io.github.cdsap.talaiot.metrics.GradleSwitchBuildScanMetric
 import io.github.cdsap.talaiot.metrics.GradleSwitchCachingMetric
 import io.github.cdsap.talaiot.metrics.GradleSwitchConfigurationCacheMetric
 import io.github.cdsap.talaiot.metrics.GradleSwitchConfigureOnDemandMetric
-import io.github.cdsap.talaiot.metrics.GradleSwitchDaemonMetric
 import io.github.cdsap.talaiot.metrics.GradleSwitchDryRunMetric
 import io.github.cdsap.talaiot.metrics.GradleSwitchParallelMetric
 import io.github.cdsap.talaiot.metrics.GradleSwitchRefreshDependenciesMetric
@@ -22,6 +22,7 @@ import io.github.cdsap.talaiot.metrics.JavaVmNameMetric
 import io.github.cdsap.talaiot.metrics.JvmMaxPermSizeMetric
 import io.github.cdsap.talaiot.metrics.JvmXmsMetric
 import io.github.cdsap.talaiot.metrics.JvmXmxMetric
+import io.github.cdsap.talaiot.metrics.KotlinProcessMetrics
 import io.github.cdsap.talaiot.metrics.LocaleMetric
 import io.github.cdsap.talaiot.metrics.OsMetric
 import io.github.cdsap.talaiot.metrics.ProcessorCountMetric
@@ -29,6 +30,7 @@ import io.github.cdsap.talaiot.metrics.RootProjectNameMetric
 import io.github.cdsap.talaiot.metrics.SimpleMetric
 import io.github.cdsap.talaiot.metrics.UserMetric
 import io.github.cdsap.talaiot.metrics.base.Metric
+import io.github.cdsap.valuesourceprocess.jInfo
 import org.gradle.api.Project
 
 /**
@@ -51,7 +53,6 @@ import org.gradle.api.Project
  *  [RootProjectNameMetric]
  *  [GradleRequestedTasksMetric]
  *  [GradleVersionMetric]
- *  [GradleScanLinkMetric]
  *
  * [gitMetrics] includes:
  *  [GitUserMetric]
@@ -76,12 +77,16 @@ import org.gradle.api.Project
  *  [GradleSwitchDryRunMetric]
  *  [GradleSwitchRefreshDependenciesMetric]
  *  [GradleSwitchRerunTasksMetric]
- *  [GradleSwitchDaemonMetric]
  *  [GradleSwitchConfigurationCacheMetric]
  *
  * [environmentMetrics] includes:
  *  [HostnameMetric]
  *  [DefaultCharsetMetric]
+ *
+ * [processMetrics] includes:
+ *  [GradleProcessMetrics]
+ *  [KotlinProcessMetrics]
+
  *
  *  If you want to define custom metrics:
  *
@@ -113,6 +118,7 @@ class MetricsConfiguration {
     var performanceMetrics = true
     var gradleSwitchesMetrics = true
     var environmentMetrics = true
+    var processMetrics = true
 
     private var metrics: MutableSet<Metric<*, *>> = mutableSetOf()
 
@@ -161,7 +167,6 @@ class MetricsConfiguration {
             add(GradleSwitchDryRunMetric())
             add(GradleSwitchRefreshDependenciesMetric())
             add(GradleSwitchRerunTasksMetric())
-            add(GradleSwitchDaemonMetric())
             add(GradleSwitchConfigurationCacheMetric())
         }
     }
@@ -264,8 +269,15 @@ class MetricsConfiguration {
         if (generateBuildId) {
             metrics.add(BuildIdMetric())
         }
-
+        if (processMetrics) {
+            addProcessMetrics(target)
+        }
         return metrics.toList()
+    }
+
+    private fun addProcessMetrics(target: Project) {
+        metrics.add(GradleProcessMetrics(target.jInfo("GradleDaemon")))
+        metrics.add(KotlinProcessMetrics(target.jInfo("KotlinCompileDaemon")))
     }
 
     private fun createSimpleBuildMetric(pair: Pair<String, String>): SimpleMetric<String> {

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/entities/ExecutionReport.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/entities/ExecutionReport.kt
@@ -71,7 +71,16 @@ data class Environment(
     var gitBranch: String? = null,
     var gitUser: String? = null,
     var switches: Switches = Switches(),
-    var hostname: String? = null
+    var hostname: String? = null,
+    var gradleJvmArgs: Map<String, String>? = null,
+    var gradleProcessesAvailable: Int? = null,
+    var multipleGradleProcesses: Boolean? = null,
+    var multipleGradleJvmArgs: Map<String, Map<String, String>>? = null,
+    var kotlinJvmArgs: Map<String, String>? = null,
+    var kotlinProcessesAvailable: Int? = null,
+    var multipleKotlinProcesses: Boolean? = null,
+    var multipleKotlinJvmArgs: Map<String, Map<String, String>>? = null,
+    var processesStats: Processes = Processes()
 ) : java.io.Serializable
 
 data class Switches(

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/entities/Processes.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/entities/Processes.kt
@@ -1,0 +1,8 @@
+package io.github.cdsap.talaiot.entities
+
+import java.io.Serializable
+
+data class Processes(
+    val listKotlinProcesses: List<io.github.cdsap.jdk.tools.parser.model.Process> = emptyList(),
+    val listGradleProcesses: List<io.github.cdsap.jdk.tools.parser.model.Process> = emptyList()
+) : Serializable

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/entities/TaskLength.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/entities/TaskLength.kt
@@ -39,8 +39,10 @@ data class TaskLength(
      * Timestamp of finish in millis
      */
     val stopMs: Long = 0L,
+
     /**
-     * task is on the critical path of execution
+     * task type
      */
-    // var critical: Boolean = false
+    val type: String
+
 ) : java.io.Serializable

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/GradleMetrics.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/GradleMetrics.kt
@@ -7,9 +7,7 @@ import io.github.cdsap.talaiot.util.TaskAbbreviationMatcher
 import io.github.cdsap.talaiot.util.TaskName
 import org.gradle.api.Project
 import org.gradle.api.internal.StartParameterInternal
-import org.gradle.api.internal.project.DefaultProject
 import org.gradle.api.invocation.Gradle
-import org.gradle.launcher.daemon.server.scaninfo.DaemonScanInfo
 
 class RootProjectNameMetric : GradleMetric<String>(
     provider = { it.gradle.rootProject.name },
@@ -59,15 +57,6 @@ class GradleSwitchOfflineMetric : GradleMetric<String>(
 class GradleSwitchRefreshDependenciesMetric : GradleMetric<String>(
     provider = { it.gradle.startParameter.isRefreshDependencies.toString() },
     assigner = { report, value -> report.environment.switches.refreshDependencies = value }
-)
-
-class GradleSwitchDaemonMetric : GradleMetric<String?>(
-    provider = {
-        val daemonScanInfo: DaemonScanInfo? =
-            (it.rootProject as DefaultProject).services.get(DaemonScanInfo::class.java)
-        daemonScanInfo?.isSingleUse?.toString()
-    },
-    assigner = { report, value -> report.environment.switches.daemon = value }
 )
 
 class GradleSwitchConfigurationCacheMetric : GradleMetric<String?>(

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/GradleProcessMetrics.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/GradleProcessMetrics.kt
@@ -1,0 +1,19 @@
+package io.github.cdsap.talaiot.metrics
+
+import io.github.cdsap.talaiot.metrics.process.JInfoProcess
+import org.gradle.api.provider.Provider
+
+class GradleProcessMetrics(val value: Provider<String>) : SimpleMetric<Provider<String>>(provider = {
+    value
+}, assigner = { report, value ->
+        val jInfoByProcess = JInfoProcess().parseJInfoData(value.get())
+        if (jInfoByProcess.isNotEmpty()) {
+            report.environment.gradleProcessesAvailable = jInfoByProcess.size
+            report.environment.multipleGradleProcesses = jInfoByProcess.size > 1
+            if (jInfoByProcess.size == 1) {
+                report.environment.gradleJvmArgs = jInfoByProcess.entries.first().value
+            } else {
+                report.environment.multipleGradleJvmArgs = jInfoByProcess
+            }
+        }
+    })

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/KotlinProcessMetrics.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/KotlinProcessMetrics.kt
@@ -1,0 +1,19 @@
+package io.github.cdsap.talaiot.metrics
+
+import io.github.cdsap.talaiot.metrics.process.JInfoProcess
+import org.gradle.api.provider.Provider
+
+class KotlinProcessMetrics(val value: Provider<String>) : SimpleMetric<Provider<String>>(provider = {
+    value
+}, assigner = { report, value ->
+        val jInfoByProcess = JInfoProcess().parseJInfoData(value.get())
+        if (jInfoByProcess.isNotEmpty()) {
+            report.environment.kotlinProcessesAvailable = jInfoByProcess.size
+            report.environment.multipleKotlinProcesses = jInfoByProcess.size > 1
+            if (jInfoByProcess.size == 1) {
+                report.environment.kotlinJvmArgs = jInfoByProcess.entries.first().value
+            } else {
+                report.environment.multipleKotlinJvmArgs = jInfoByProcess
+            }
+        }
+    })

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/process/JInfoProcess.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/process/JInfoProcess.kt
@@ -1,0 +1,36 @@
+package io.github.cdsap.talaiot.metrics.process
+
+/* Parse output of jinfo command for a given type of process
+
+ */
+class JInfoProcess {
+    fun parseJInfoData(content: String): Map<String, Map<String, String>> {
+        val mapInfoProcesses = mutableMapOf<String, Map<String, String>>()
+        val lines = content.split("\n")
+        if (lines.last().trim() == "") {
+            lines.dropLast(1)
+        }
+        val numberOfProcess = lines.size / 2
+        var auxIndex = 0
+        for (i in 0 until numberOfProcess) {
+            val flags = parseVmFlags(lines[auxIndex])
+            val process = lines[++auxIndex].split("\\s+".toRegex()).first()
+            mapInfoProcesses[process] = flags
+            auxIndex++
+        }
+        return mapInfoProcesses
+    }
+
+    private fun parseVmFlags(vmFlags: String): Map<String, String> {
+        val flags = mutableMapOf<String, String>()
+        vmFlags.trim().split(" ").forEach { flag ->
+            if (flag.contains("=")) {
+                val property = flag.split("=")
+                flags[property[0]] = property[1]
+            } else {
+                flags[flag] = "true"
+            }
+        }
+        return flags
+    }
+}

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisher.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisher.kt
@@ -15,6 +15,11 @@ interface TalaiotPublisher : java.io.Serializable {
         success: Boolean,
         duration: Long,
         publishers: List<Publisher>,
-        configurationCacheHit: Boolean
+        configurationCacheHit: Boolean,
+        gradleStat: String,
+        kotlinStat: String,
+        gradleInfo: String,
+        kotlinInfo: String,
+        processProcessMetrics: Boolean
     )
 }

--- a/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/entities/ExecutionReportTest.kt
+++ b/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/entities/ExecutionReportTest.kt
@@ -12,14 +12,21 @@ class ExecutionReportTest : BehaviorSpec({
                 taskName = "task1",
                 taskPath = "module:task1",
                 state = TaskMessageState.EXECUTED,
-                module = "module"
+                module = "module",
+                startMs = 0L,
+                stopMs = 1L,
+                type = "awesomeTask"
+
             ),
             TaskLength(
                 ms = 1000L,
                 taskName = "task2",
                 taskPath = "module:task2",
                 state = TaskMessageState.FROM_CACHE,
-                module = "module"
+                module = "module",
+                startMs = 0L,
+                stopMs = 1L,
+                type = "awesomeTask"
             )
         )
 

--- a/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/filter/TaskFilterProcessorTest.kt
+++ b/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/filter/TaskFilterProcessorTest.kt
@@ -97,5 +97,8 @@ fun getTask(module: String, name: String, duration: Long = 1L) = TaskLength(
     taskPath = "$module:$name",
     state = TaskMessageState.EXECUTED,
     rootNode = false,
-    module = module
+    module = module,
+    startMs = 0L,
+    stopMs = 1L,
+    type = "awesomeTask"
 )

--- a/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/DefaultTaskMetricsProviderTest.kt
+++ b/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/DefaultTaskMetricsProviderTest.kt
@@ -16,7 +16,9 @@ class DefaultTaskMetricsProviderTest : BehaviorSpec({
                     taskPath = "module:task1",
                     state = TaskMessageState.EXECUTED,
                     module = "module",
-                    rootNode = false
+                    startMs = 0L,
+                    stopMs = 1L,
+                    type = "awesomeTask"
                 ),
                 ExecutionReportProvider.executionReport()
             ).get()

--- a/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/GradleProcessMetricsTest.kt
+++ b/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/GradleProcessMetricsTest.kt
@@ -1,0 +1,60 @@
+package io.github.cdsap.talaiot.metrics
+
+import io.github.cdsap.talaiot.entities.ExecutionReport
+import io.kotlintest.specs.BehaviorSpec
+import org.gradle.api.internal.provider.Providers
+
+class GradleProcessMetricsTest : BehaviorSpec({
+    given("a Gradle Process Metrics object") {
+        `when`("There are more than one Gradle Process") {
+            val provider = Providers.of(
+                """
+                    -XX:CICompilerCount=4 -XX:ConcGCThreads=2 -XX:G1ConcRefinementThreads=9 -XX:G1HeapRegionSize=1048576 -XX:GCDrainStackTargetSize=64 -XX:InitialHeapSize=1073741824 -XX:MarkStackSize=4194304 -XX:MaxHeapSize=4294967296 -XX:MaxNewSize=2576351232 -XX:MinHeapDeltaBytes=1048576 -XX:NonNMethodCodeHeapSize=5836492 -XX:NonProfiledCodeHeapSize=122910874 -XX:ProfiledCodeHeapSize=122910874 -XX:ReservedCodeCacheSize=251658240 -XX:+SegmentedCodeCache -XX:-UseAOT -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseG1GC
+                    8848
+                    -XX:CICompilerCount=4 -XX:CompressedClassSpaceSize=859832320 -XX:+HeapDumpOnOutOfMemoryError -XX:InitialHeapSize=1073741824 -XX:MaxHeapSize=3221225472 -XX:MaxMetaspaceSize=1073741824 -XX:MaxNewSize=1073741824 -XX:MinHeapDeltaBytes=524288 -XX:MinHeapSize=8388608 -XX:NewSize=357564416 -XX:NonNMethodCodeHeapSize=5839564 -XX:NonProfiledCodeHeapSize=122909338 -XX:OldSize=716177408 -XX:ProfiledCodeHeapSize=122909338 -XX:ReservedCodeCacheSize=251658240 -XX:+SegmentedCodeCache -XX:SoftMaxHeapSize=3221225472 -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:-UseNUMA -XX:-UseNUMAInterleaving -XX:+UseParallelGC
+                    9105
+                """.trimIndent()
+            )
+
+            val executionReport = ExecutionReport()
+            GradleProcessMetrics(provider).get(Unit, executionReport)
+            then("Execution Report sets multipleGradleProcesses and parse correctly 2 different processes") {
+                assert(executionReport.environment.multipleGradleProcesses == true)
+                assert(executionReport.environment.gradleProcessesAvailable == 2)
+                assert(
+                    executionReport.environment.multipleGradleJvmArgs?.get("8848")?.get("-XX:CICompilerCount") == "4"
+                )
+                assert(
+                    executionReport.environment.multipleGradleJvmArgs?.get("8848")
+                        ?.get("-XX:G1HeapRegionSize") == "1048576"
+                )
+                assert(
+                    executionReport.environment.multipleGradleJvmArgs?.get("9105")
+                        ?.get("-XX:CompressedClassSpaceSize") == "859832320"
+                )
+                assert(
+                    executionReport.environment.multipleGradleJvmArgs?.get("9105")
+                        ?.get("-XX:+HeapDumpOnOutOfMemoryError") == "true"
+                )
+            }
+        }
+        `when`("There is only one Gradle Process") {
+            val provider = Providers.of(
+                """
+                    -XX:CICompilerCount=4 -XX:ConcGCThreads=2 -XX:G1ConcRefinementThreads=9 -XX:G1HeapRegionSize=1048576 -XX:GCDrainStackTargetSize=64 -XX:InitialHeapSize=1073741824 -XX:MarkStackSize=4194304 -XX:MaxHeapSize=4294967296 -XX:MaxNewSize=2576351232 -XX:MinHeapDeltaBytes=1048576 -XX:NonNMethodCodeHeapSize=5836492 -XX:NonProfiledCodeHeapSize=122910874 -XX:ProfiledCodeHeapSize=122910874 -XX:ReservedCodeCacheSize=251658240 -XX:+SegmentedCodeCache -XX:-UseAOT -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseG1GC
+                    8848
+                """.trimIndent()
+            )
+
+            val executionReport = ExecutionReport()
+            GradleProcessMetrics(provider).get(Unit, executionReport)
+            then("Execution Report sets multipleGradleProcesses and parse correctly 2 different processes") {
+                assert(executionReport.environment.multipleGradleProcesses == false)
+                assert(executionReport.environment.gradleProcessesAvailable == 1)
+                assert(executionReport.environment.gradleJvmArgs?.get("-XX:CICompilerCount") == "4")
+                assert(executionReport.environment.gradleJvmArgs?.get("-XX:ConcGCThreads") == "2")
+                assert(executionReport.environment.gradleJvmArgs?.get("-XX:+UseG1GC") == "true")
+            }
+        }
+    }
+})

--- a/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/KotlinProcessMetricsTest.kt
+++ b/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/KotlinProcessMetricsTest.kt
@@ -1,0 +1,67 @@
+package io.github.cdsap.talaiot.metrics
+
+import io.github.cdsap.talaiot.entities.ExecutionReport
+import io.kotlintest.specs.BehaviorSpec
+import org.gradle.api.internal.provider.Providers
+
+class KotlinProcessMetricsTest : BehaviorSpec({
+    given("a Kotlin Process Metrics object") {
+        `when`("There are more than one Kotlin Process") {
+            val provider = Providers.of(
+                """
+                -XX:CICompilerCount=4 -XX:CompressedClassSpaceSize=859832320 -XX:ConcGCThreads=2 -XX:G1ConcRefinementThreads=9 -XX:G1EagerReclaimRemSetThreshold=16 -XX:G1HeapRegionSize=2097152 -XX:GCDrainStackTargetSize=64 -XX:InitialHeapSize=1073741824 -XX:MarkStackSize=4194304 -XX:MaxHeapSize=3221225472 -XX:MaxMetaspaceSize=1073741824 -XX:MaxNewSize=1931476992 -XX:MinHeapDeltaBytes=2097152 -XX:MinHeapSize=8388608 -XX:NonNMethodCodeHeapSize=5839564 -XX:NonProfiledCodeHeapSize=122909338 -XX:ProfiledCodeHeapSize=122909338 -XX:ReservedCodeCacheSize=251658240 -XX:+SegmentedCodeCache -XX:SoftMaxHeapSize=3221225472 -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseG1GC -XX:-UseNUMA -XX:-UseNUMAInterleaving
+                41922
+                -XX:CICompilerCount=4 -XX:ConcGCThreads=2 -XX:G1ConcRefinementThreads=9 -XX:G1HeapRegionSize=1048576 -XX:GCDrainStackTargetSize=64 -XX:InitialHeapSize=1073741824 -XX:MarkStackSize=4194304 -XX:MaxHeapSize=4294967296 -XX:MaxNewSize=2576351232 -XX:MinHeapDeltaBytes=1048576 -XX:NonNMethodCodeHeapSize=5836492 -XX:NonProfiledCodeHeapSize=122910874 -XX:ProfiledCodeHeapSize=122910874 -XX:ReservedCodeCacheSize=251658240 -XX:+SegmentedCodeCache -XX:-UseAOT -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseG1GC
+                3442
+                -XX:CICompilerCount=4 -XX:ConcGCThreads=2 -XX:G1ConcRefinementThreads=9 -XX:G1EagerReclaimRemSetThreshold=8 -XX:G1HeapRegionSize=1048576 -XX:GCDrainStackTargetSize=64 -XX:InitialHeapSize=1073741824 -XX:MarkStackSize=4194304 -XX:MaxHeapSize=2147483648 -XX:MaxNewSize=1287651328 -XX:MinHeapDeltaBytes=1048576 -XX:MinHeapSize=8388608 -XX:NonNMethodCodeHeapSize=5839564 -XX:NonProfiledCodeHeapSize=122909338 -XX:ProfiledCodeHeapSize=122909338 -XX:ReservedCodeCacheSize=251658240 -XX:+SegmentedCodeCache -XX:SoftMaxHeapSize=2147483648 -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseG1GC -XX:-UseNUMA -XX:-UseNUMAInterleaving
+                34905
+                """.trimIndent()
+            )
+
+            val executionReport = ExecutionReport()
+            KotlinProcessMetrics(provider).get(Unit, executionReport)
+            then("Execution Report sets multipleKotlinProcesses and parse correctly 2 different processes") {
+                val env = executionReport.environment
+                assert(env.multipleKotlinProcesses == true)
+                assert(env.kotlinProcessesAvailable == 3)
+                assert(env.multipleKotlinJvmArgs?.get("41922")?.get("-XX:CICompilerCount") == "4")
+                assert(env.multipleKotlinJvmArgs?.get("41922")?.get("-XX:G1HeapRegionSize") == "2097152")
+                assert(env.multipleKotlinJvmArgs?.get("3442")?.get("-XX:G1ConcRefinementThreads") == "9")
+                assert(env.multipleKotlinJvmArgs?.get("3442")?.get("-XX:G1HeapRegionSize") == "1048576")
+                assert(env.multipleKotlinJvmArgs?.get("34905")?.get("-XX:G1EagerReclaimRemSetThreshold") == "8")
+                assert(env.multipleKotlinJvmArgs?.get("34905")?.get("-XX:G1HeapRegionSize") == "1048576")
+            }
+        }
+        `when`("There is only one Kotlin Process") {
+            val provider = Providers.of(
+                """
+                -XX:CICompilerCount=4 -XX:CompressedClassSpaceSize=859832320 -XX:ConcGCThreads=2 -XX:G1ConcRefinementThreads=9 -XX:G1EagerReclaimRemSetThreshold=16 -XX:G1HeapRegionSize=2097152 -XX:GCDrainStackTargetSize=64 -XX:InitialHeapSize=1073741824 -XX:MarkStackSize=4194304 -XX:MaxHeapSize=3221225472 -XX:MaxMetaspaceSize=1073741824 -XX:MaxNewSize=1931476992 -XX:MinHeapDeltaBytes=2097152 -XX:MinHeapSize=8388608 -XX:NonNMethodCodeHeapSize=5839564 -XX:NonProfiledCodeHeapSize=122909338 -XX:ProfiledCodeHeapSize=122909338 -XX:ReservedCodeCacheSize=251658240 -XX:+SegmentedCodeCache -XX:SoftMaxHeapSize=3221225472 -XX:+UseCompressedClassPointers -XX:+UseCompressedOops -XX:+UseG1GC -XX:-UseNUMA -XX:-UseNUMAInterleaving
+                41922
+                """.trimIndent()
+            )
+
+            val executionReport = ExecutionReport()
+            KotlinProcessMetrics(provider).get(Unit, executionReport)
+            then("Execution Report sets multipleKotlinProcesses and parse correctly 2 different processes") {
+                assert(executionReport.environment.multipleKotlinProcesses == false)
+                assert(executionReport.environment.kotlinProcessesAvailable == 1)
+                assert(executionReport.environment.kotlinJvmArgs?.get("-XX:CICompilerCount") == "4")
+                assert(executionReport.environment.kotlinJvmArgs?.get("-XX:CompressedClassSpaceSize") == "859832320")
+                assert(executionReport.environment.kotlinJvmArgs?.get("-XX:+UseG1GC") == "true")
+            }
+        }
+        `when`("There is no Kotlin Process") {
+            val provider = Providers.of(
+                """
+                """.trimIndent()
+            )
+
+            val executionReport = ExecutionReport()
+            KotlinProcessMetrics(provider).get(Unit, executionReport)
+            then("Values are not set in Execution Report") {
+                assert(executionReport.environment.multipleKotlinProcesses == null)
+                assert(executionReport.environment.kotlinProcessesAvailable == null)
+            }
+        }
+    }
+})

--- a/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/report/ExecutionReportProvider.kt
+++ b/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/report/ExecutionReportProvider.kt
@@ -38,7 +38,10 @@ object ExecutionReportProvider {
                     ":assemble",
                     TaskMessageState.EXECUTED,
                     false,
-                    "app"
+                    "app",
+                    startMs = 0L,
+                    stopMs = 1L,
+                    type = "awesomeTask"
                 )
             )
         )
@@ -86,7 +89,10 @@ object ExecutionReportProvider {
                 ":clean",
                 TaskMessageState.EXECUTED,
                 false,
-                "app"
+                "app",
+                startMs = 0L,
+                stopMs = 1L,
+                type = "awesomeTask"
             )
         )
     )

--- a/library/plugins/base/base-publisher/src/test/java/io/github/cdsap/talaiot/publisher/OutputPublisherTest.kt
+++ b/library/plugins/base/base-publisher/src/test/java/io/github/cdsap/talaiot/publisher/OutputPublisherTest.kt
@@ -40,7 +40,10 @@ class OutputPublisherTest : BehaviorSpec({
                             ":averageTask",
                             TaskMessageState.EXECUTED,
                             true,
-                            "app"
+                            "app",
+                            0L,
+                            1L,
+                            "awesomeTask"
                         ),
                         TaskLength(
                             30L,
@@ -48,7 +51,10 @@ class OutputPublisherTest : BehaviorSpec({
                             ":slowTask",
                             TaskMessageState.EXECUTED,
                             true,
-                            "app"
+                            "app",
+                            0L,
+                            1L,
+                            "awesomeTask"
                         ),
                         TaskLength(
                             10L,
@@ -56,7 +62,10 @@ class OutputPublisherTest : BehaviorSpec({
                             ":fastTask",
                             TaskMessageState.EXECUTED,
                             true,
-                            "app"
+                            "app",
+                            0L,
+                            1L,
+                            "awesomeTask"
                         )
                     )
                 )
@@ -101,7 +110,10 @@ class OutputPublisherTest : BehaviorSpec({
                             ":averageTask",
                             TaskMessageState.EXECUTED,
                             true,
-                            "app"
+                            "app",
+                            0L,
+                            1L,
+                            "awesomeTask"
                         ),
                         TaskLength(
                             30L,
@@ -109,7 +121,10 @@ class OutputPublisherTest : BehaviorSpec({
                             ":slowTask",
                             TaskMessageState.EXECUTED,
                             true,
-                            "app"
+                            "app",
+                            0L,
+                            1L,
+                            "awesomeTask"
                         ),
                         TaskLength(
                             10L,
@@ -117,7 +132,10 @@ class OutputPublisherTest : BehaviorSpec({
                             ":fastTask",
                             TaskMessageState.EXECUTED,
                             true,
-                            "app"
+                            "app",
+                            0L,
+                            1L,
+                            "awesomeTask"
                         )
                     )
                 )
@@ -163,7 +181,10 @@ class OutputPublisherTest : BehaviorSpec({
                             ":zeroTask",
                             TaskMessageState.EXECUTED,
                             true,
-                            "app"
+                            "app",
+                            0L,
+                            1L,
+                            "awesomeTask"
                         )
                     )
                 )
@@ -197,7 +218,10 @@ class OutputPublisherTest : BehaviorSpec({
                             ":secTask",
                             TaskMessageState.EXECUTED,
                             true,
-                            "app"
+                            "app",
+                            0L,
+                            1L,
+                            "awesomeTask"
                         ),
                         TaskLength(
                             65_000L,
@@ -205,7 +229,10 @@ class OutputPublisherTest : BehaviorSpec({
                             ":minTask",
                             TaskMessageState.EXECUTED,
                             true,
-                            "app"
+                            "app",
+                            0L,
+                            1L,
+                            "awesomeTask"
                         ),
                         TaskLength(
                             10L,
@@ -213,7 +240,10 @@ class OutputPublisherTest : BehaviorSpec({
                             ":msTask",
                             TaskMessageState.EXECUTED,
                             true,
-                            "app"
+                            "app",
+                            0L,
+                            1L,
+                            "awesomeTask"
                         )
                     )
                 )
@@ -260,7 +290,10 @@ class OutputPublisherTest : BehaviorSpec({
                             ":averageTask",
                             TaskMessageState.EXECUTED,
                             true,
-                            "app"
+                            "app",
+                            0L,
+                            1L,
+                            "awesomeTask"
                         ),
                         TaskLength(
                             30L,
@@ -268,7 +301,10 @@ class OutputPublisherTest : BehaviorSpec({
                             ":slowTask",
                             TaskMessageState.EXECUTED,
                             true,
-                            "app"
+                            "app",
+                            0L,
+                            1L,
+                            "awesomeTask"
                         ),
                         TaskLength(
                             10L,
@@ -276,7 +312,10 @@ class OutputPublisherTest : BehaviorSpec({
                             ":fastTask",
                             TaskMessageState.EXECUTED,
                             true,
-                            "app"
+                            "app",
+                            0L,
+                            1L,
+                            "awesomeTask"
                         )
                     )
                 )

--- a/library/plugins/elastic-search/elastic-search-publisher/src/test/kotlin/io/github/cdsap/talaiot/publisher/elasticsearch/ElasticSearchPublisherTest.kt
+++ b/library/plugins/elastic-search/elastic-search-publisher/src/test/kotlin/io/github/cdsap/talaiot/publisher/elasticsearch/ElasticSearchPublisherTest.kt
@@ -228,7 +228,10 @@ class ElasticSearchPublisherTest : BehaviorSpec() {
                     ":assemble",
                     TaskMessageState.EXECUTED,
                     false,
-                    "app"
+                    "app",
+                    0L,
+                    1L,
+                    "awesomeTask"
                 )
             )
         )

--- a/library/plugins/hybrid/hybrid-publisher/src/test/kotlin/io/github/cdsap/talaiot/publisher/HybridPublisherTest.kt
+++ b/library/plugins/hybrid/hybrid-publisher/src/test/kotlin/io/github/cdsap/talaiot/publisher/HybridPublisherTest.kt
@@ -89,7 +89,10 @@ class HybridPublisherTest : BehaviorSpec() {
                                     ":clean",
                                     TaskMessageState.EXECUTED,
                                     false,
-                                    "app"
+                                    "app",
+                                    0L,
+                                    1L,
+                                    "awesomeCleanTask"
                                 )
                             )
                         )
@@ -143,7 +146,10 @@ class HybridPublisherTest : BehaviorSpec() {
                                     ":clean",
                                     TaskMessageState.EXECUTED,
                                     false,
-                                    "app"
+                                    "app",
+                                    0L,
+                                    1L,
+                                    "awesomeCleanTask"
                                 )
                             )
                         )
@@ -174,7 +180,10 @@ class HybridPublisherTest : BehaviorSpec() {
                                     ":clean",
                                     TaskMessageState.EXECUTED,
                                     false,
-                                    "app"
+                                    "app",
+                                    0L,
+                                    1L,
+                                    "awesomeCleanTask"
                                 )
                             )
                         )
@@ -217,7 +226,10 @@ class HybridPublisherTest : BehaviorSpec() {
                                     ":clean",
                                     TaskMessageState.EXECUTED,
                                     false,
-                                    "app"
+                                    "app",
+                                    0L,
+                                    1L,
+                                    "awesomeCleanTask"
                                 )
                             )
                         )

--- a/library/plugins/influxdb/influxdb-publisher/src/test/kotlin/io/github/cdsap/talaiot/publisher/influxdb/InfluxDbPublisherTest.kt
+++ b/library/plugins/influxdb/influxdb-publisher/src/test/kotlin/io/github/cdsap/talaiot/publisher/influxdb/InfluxDbPublisherTest.kt
@@ -259,7 +259,10 @@ class InfluxDbPublisherTest : BehaviorSpec() {
                     ":assemble",
                     TaskMessageState.EXECUTED,
                     false,
-                    "app"
+                    "app",
+                    0L,
+                    1L,
+                    "awesomeTask"
                 )
             )
         )

--- a/library/plugins/influxdb/influxdb2-publisher/src/test/kotlin/io/github/cdsap/talaiot/publisher/influxdb2/InfluxDb2PublisherTest.kt
+++ b/library/plugins/influxdb/influxdb2-publisher/src/test/kotlin/io/github/cdsap/talaiot/publisher/influxdb2/InfluxDb2PublisherTest.kt
@@ -135,7 +135,10 @@ class InfluxDb2PublisherTest : BehaviorSpec() {
                     ":assemble",
                     TaskMessageState.EXECUTED,
                     false,
-                    "app"
+                    "app",
+                    0L,
+                    1L,
+                    "awesomeTask"
                 )
             )
         )

--- a/library/plugins/pushgateway/pushgateway-publisher/src/test/kotlin/io/github/cdsap/talaiot/publisher/pushgateway/PushGatewayLabelProviderTest.kt
+++ b/library/plugins/pushgateway/pushgateway-publisher/src/test/kotlin/io/github/cdsap/talaiot/publisher/pushgateway/PushGatewayLabelProviderTest.kt
@@ -31,7 +31,10 @@ class PushGatewayLabelProviderTest : BehaviorSpec() {
                         ":clean",
                         TaskMessageState.EXECUTED,
                         false,
-                        "app"
+                        "app",
+                        0L,
+                        1L,
+                        "awesomeTask"
                     )
                 )
                 then(" Task metric values are present") {
@@ -54,7 +57,10 @@ class PushGatewayLabelProviderTest : BehaviorSpec() {
                         ":clean",
                         TaskMessageState.EXECUTED,
                         false,
-                        "app"
+                        "app",
+                        0L,
+                        1L,
+                        "awesomeTask"
                     )
                 )
                 then("custom task label values metrics are present") {
@@ -120,7 +126,10 @@ class PushGatewayLabelProviderTest : BehaviorSpec() {
                     ":clean",
                     TaskMessageState.EXECUTED,
                     false,
-                    "app"
+                    "app",
+                    0L,
+                    1L,
+                    "awesomeTask"
                 ),
                 TaskLength(
                     100,
@@ -128,7 +137,10 @@ class PushGatewayLabelProviderTest : BehaviorSpec() {
                     ":app:assemble",
                     TaskMessageState.EXECUTED,
                     false,
-                    "app"
+                    "app",
+                    0L,
+                    1L,
+                    "awesomeTask"
                 )
             )
         )

--- a/library/plugins/pushgateway/pushgateway-publisher/src/test/kotlin/io/github/cdsap/talaiot/publisher/pushgateway/PushGatewayPublisherTest.kt
+++ b/library/plugins/pushgateway/pushgateway-publisher/src/test/kotlin/io/github/cdsap/talaiot/publisher/pushgateway/PushGatewayPublisherTest.kt
@@ -242,7 +242,10 @@ class PushGatewayPublisherTest : BehaviorSpec() {
                     ":clean",
                     TaskMessageState.EXECUTED,
                     false,
-                    "app"
+                    "app",
+                    0L,
+                    1L,
+                    "awesomeTask"
                 ),
                 TaskLength(
                     100,
@@ -250,7 +253,10 @@ class PushGatewayPublisherTest : BehaviorSpec() {
                     ":app:assemble",
                     TaskMessageState.EXECUTED,
                     false,
-                    "app"
+                    "app",
+                    0L,
+                    1L,
+                    "awesomeTask"
                 )
             )
         )
@@ -285,7 +291,10 @@ class PushGatewayPublisherTest : BehaviorSpec() {
                     ":test-module:clean",
                     TaskMessageState.EXECUTED,
                     false,
-                    ":test-module"
+                    ":test-module",
+                    0L,
+                    1L,
+                    "awesomeTask"
                 ),
                 TaskLength(
                     100,
@@ -293,7 +302,10 @@ class PushGatewayPublisherTest : BehaviorSpec() {
                     ":test-module:app:assemble",
                     TaskMessageState.EXECUTED,
                     false,
-                    ":test-module"
+                    ":test-module",
+                    0L,
+                    1L,
+                    "awesomeTask"
                 )
             )
         )

--- a/library/plugins/rethinkdb/rethinkdb-publisher/src/test/kotlin/io/github/cdsap/talaiot/publisher/rethinkdb/RethinkDbPublisherTest.kt
+++ b/library/plugins/rethinkdb/rethinkdb-publisher/src/test/kotlin/io/github/cdsap/talaiot/publisher/rethinkdb/RethinkDbPublisherTest.kt
@@ -186,7 +186,10 @@ class RethinkDbPublisherTest : BehaviorSpec() {
                     ":clean",
                     TaskMessageState.EXECUTED,
                     false,
-                    "app"
+                    "app",
+                    0L,
+                    1L,
+                    "awesomeTask"
                 ),
                 TaskLength(
                     100,
@@ -194,7 +197,10 @@ class RethinkDbPublisherTest : BehaviorSpec() {
                     ":app:assemble",
                     TaskMessageState.EXECUTED,
                     false,
-                    "app"
+                    "app",
+                    0L,
+                    1L,
+                    "awesomeTask"
                 )
             )
         )

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/ConfigurationCacheHit.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/ConfigurationCacheHit.kt
@@ -42,12 +42,15 @@ class ConfigurationCacheHit : StringSpec({
 
                 """.trimIndent()
             )
-            GradleRunner.create()
+            val B = GradleRunner.create()
                 .withProjectDir(testProjectDir.getRoot())
                 .withArguments("assemble", "--info", "--configuration-cache")
                 .withPluginClasspath()
                 .withGradleVersion(version)
                 .build()
+            println(version)
+            println(B.output)
+
             Thread.sleep(5000)
             val reportFile = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
             val report = Gson().fromJson(reportFile.readText(), ExecutionReport::class.java)
@@ -55,13 +58,15 @@ class ConfigurationCacheHit : StringSpec({
             report.configurationCacheHit shouldBe false
             report.configurationDurationMs shouldNotStartWith "0"
 
-            GradleRunner.create()
+            val a = GradleRunner.create()
                 .withProjectDir(testProjectDir.getRoot())
                 .withArguments("assemble", "--info", "--configuration-cache")
                 .withPluginClasspath()
                 .withGradleVersion(version)
                 .build()
             Thread.sleep(5000)
+            println(version)
+            println(a.output)
             val reportFileHit = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
             val reportHit = Gson().fromJson(reportFileHit.readText(), ExecutionReport::class.java)
 

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/ConfigurationCacheHit.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/ConfigurationCacheHit.kt
@@ -42,14 +42,12 @@ class ConfigurationCacheHit : StringSpec({
 
                 """.trimIndent()
             )
-            val B = GradleRunner.create()
+            GradleRunner.create()
                 .withProjectDir(testProjectDir.getRoot())
                 .withArguments("assemble", "--info", "--configuration-cache")
                 .withPluginClasspath()
                 .withGradleVersion(version)
                 .build()
-            println(version)
-            println(B.output)
 
             Thread.sleep(5000)
             val reportFile = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
@@ -58,15 +56,13 @@ class ConfigurationCacheHit : StringSpec({
             report.configurationCacheHit shouldBe false
             report.configurationDurationMs shouldNotStartWith "0"
 
-            val a = GradleRunner.create()
+            GradleRunner.create()
                 .withProjectDir(testProjectDir.getRoot())
                 .withArguments("assemble", "--info", "--configuration-cache")
                 .withPluginClasspath()
                 .withGradleVersion(version)
                 .build()
             Thread.sleep(5000)
-            println(version)
-            println(a.output)
             val reportFileHit = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
             val reportHit = Gson().fromJson(reportFileHit.readText(), ExecutionReport::class.java)
 

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/PostProcessesMetricsTest.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/PostProcessesMetricsTest.kt
@@ -1,0 +1,101 @@
+package io.github.cdsap.talaiot
+
+import com.google.gson.Gson
+import io.github.cdsap.talaiot.entities.ExecutionReport
+import io.github.cdsap.talaiot.utils.TemporaryFolder
+import io.kotlintest.forAll
+import io.kotlintest.matchers.numerics.shouldBeGreaterThan
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+import org.gradle.testkit.runner.GradleRunner
+import java.io.File
+
+class PostProcessesMetricsTest : StringSpec({
+    "given a build with process metrics enabled" {
+        forAll(
+            listOf(
+                "8.3"
+            )
+        ) { version: String ->
+            val testProjectDir = TemporaryFolder()
+
+            testProjectDir.create()
+            val buildFile = testProjectDir.newFile("build.gradle.kts")
+            buildFile.appendText(
+                """
+                import io.github.cdsap.talaiot.publisher.JsonPublisher
+                plugins {
+                    id ("java")
+                    id ("io.github.cdsap.talaiot")
+                }
+
+                talaiot {
+                    logger = io.github.cdsap.talaiot.logger.LogTracker.Mode.INFO
+                    publishers {
+                         jsonPublisher = true
+                    }
+                }
+
+                """.trimIndent()
+            )
+            GradleRunner.create()
+                .withProjectDir(testProjectDir.getRoot())
+                .withArguments("assemble", "--info", "--stacktrace")
+                .withPluginClasspath()
+                .withGradleVersion(version)
+                .build()
+            Thread.sleep(5000)
+            val reportFile = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
+            val report = Gson().fromJson(reportFile.readText(), ExecutionReport::class.java)
+
+            testProjectDir.delete()
+            report.environment.processesStats.listGradleProcesses.count() shouldBeGreaterThan 0
+        }
+    }
+
+    "given a build disabling the process metrics" {
+        forAll(
+            listOf(
+                "8.3"
+            )
+        ) { version: String ->
+            val testProjectDir = TemporaryFolder()
+
+            testProjectDir.create()
+            val buildFile = testProjectDir.newFile("build.gradle.kts")
+            buildFile.appendText(
+                """
+                import io.github.cdsap.talaiot.publisher.JsonPublisher
+                plugins {
+                    id ("java")
+                    id ("io.github.cdsap.talaiot")
+                }
+
+                talaiot {
+                    logger = io.github.cdsap.talaiot.logger.LogTracker.Mode.INFO
+                    publishers {
+                         jsonPublisher = true
+                    }
+                    metrics {
+                       processMetrics = false
+                    }
+                }
+
+                """.trimIndent()
+            )
+            GradleRunner.create()
+                .withProjectDir(testProjectDir.getRoot())
+                .withArguments("assemble", "--info", "--stacktrace")
+                .withPluginClasspath()
+                .withGradleVersion(version)
+                .build()
+            Thread.sleep(5000)
+            val reportFile = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
+            val report = Gson().fromJson(reportFile.readText(), ExecutionReport::class.java)
+
+            testProjectDir.delete()
+            report.environment.processesStats.listGradleProcesses.count() shouldBe 0
+            report.environment.processesStats.listKotlinProcesses.count() shouldBe 0
+        }
+    }
+})

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/TalaiotPublisherImplTest.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/TalaiotPublisherImplTest.kt
@@ -58,7 +58,12 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 true,
                 200,
                 publishers.get(),
-                true
+                true,
+                "",
+                "",
+                "",
+                "",
+                false
             )
             then("outputPublisher is publishing one task result ") {
                 assert(publishers.get().size == 1)
@@ -98,7 +103,12 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 true,
                 200,
                 publishers.get(),
-                true
+                true,
+                "",
+                "",
+                "",
+                "",
+                false
             )
 
             then("two publishers are processed ") {
@@ -150,7 +160,12 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 true,
                 200,
                 publishers.get(),
-                true
+                true,
+                "",
+                "",
+                "",
+                "",
+                false
             )
 
             then("two publishers are processed and one task has been filtered ") {
@@ -204,7 +219,12 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 true,
                 200,
                 publishers.get(),
-                true
+                true,
+                "",
+                "",
+                "",
+                "",
+                false
             )
 
             then("two publishers are processed and one task has been filtered ") {
@@ -248,7 +268,12 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 true,
                 200,
                 publishers.get(),
-                true
+                true,
+                "",
+                "",
+                "",
+                "",
+                false
             )
 
             then("successful build is published") {
@@ -287,7 +312,12 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 false,
                 200,
                 publishers.get(),
-                true
+                true,
+                "",
+                "",
+                "",
+                "",
+                false
             )
 
             then("failed build is not published") {
@@ -326,7 +356,12 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 false,
                 200,
                 publishers.get(),
-                true
+                true,
+                "",
+                "",
+                "",
+                "",
+                false
             )
 
             then("build with a different task is published") {
@@ -363,7 +398,12 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 success = true,
                 duration = 200,
                 publishers.get(),
-                true
+                true,
+                "",
+                "",
+                "",
+                "",
+                false
             )
             then("no information is published") {
                 verifyZeroInteractions(publishers.get()[0])
@@ -400,7 +440,12 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 success = false,
                 duration = 200,
                 publishers.get(),
-                true
+                true,
+                "",
+                "",
+                "",
+                "",
+                false
             )
             then("build with a different task is not published") {
 
@@ -437,7 +482,12 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 success = true,
                 duration = 200,
                 publishers.get(),
-                true
+                true,
+                "",
+                "",
+                "",
+                "",
+                false
             )
             then("build with the same task is published") {
                 verify(publishers.get()[0]).publish(any())
@@ -476,7 +526,12 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 success = true,
                 duration = 200,
                 publishers.get(),
-                true
+                true,
+                "",
+                "",
+                "",
+                "",
+                false
             )
 
             then("build with at least one task included is published") {
@@ -516,7 +571,12 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 success = true,
                 duration = 200,
                 publishers.get(),
-                true
+                true,
+                "",
+                "",
+                "",
+                "",
+                false
             )
 
             then("build with all tasks filtered out is not published") {
@@ -558,7 +618,12 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 true,
                 200,
                 publishers.get(),
-                true
+                true,
+                "",
+                "",
+                "",
+                "",
+                false
             )
             then("should publish cache information for each task") {
                 val reportCaptor = argumentCaptor<ExecutionReport>()
@@ -572,7 +637,8 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                     rootNode = false,
                     module = "app",
                     startMs = 0,
-                    stopMs = 0
+                    stopMs = 0,
+                    "awesomeTask"
                 )
 
                 val expectedTasks = listOf(
@@ -620,7 +686,12 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 true,
                 200,
                 publishers.get(),
-                true
+                true,
+                "",
+                "",
+                "",
+                "",
+                false
             )
 
             then("duration is the sum of execution and configuration") {
@@ -667,7 +738,10 @@ private fun getTasks() = mutableListOf(
         taskPath = ":app:clean",
         state = TaskMessageState.EXECUTED,
         rootNode = false,
-        module = "app"
+        module = "app",
+        startMs = 0L,
+        stopMs = 1L,
+        type = "awesomeTask"
     )
 )
 
@@ -677,5 +751,8 @@ private fun getSingleTask(name: String = "a") = TaskLength(
     taskPath = ":app:$name",
     state = TaskMessageState.EXECUTED,
     rootNode = false,
-    module = "app"
+    module = "app",
+    startMs = 0L,
+    stopMs = 1L,
+    type = "awesomeTask"
 )

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/TalaiotPublisherImplTest.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/TalaiotPublisherImplTest.kt
@@ -637,7 +637,7 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                     rootNode = false,
                     module = "app",
                     startMs = 0,
-                    stopMs = 0,
+                    stopMs = 1,
                     "awesomeTask"
                 )
 

--- a/sample/gradle/wrapper/gradle-wrapper.properties
+++ b/sample/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Adding new property in `TaskLength`:
* `type`: Represents  the type of tasks executed

Adding new properties in `ExecutionReport`:
*  `gradleJvmArgs`
*  `gradleProcessesAvailable`
*  `multipleGradleProcesses`
*  `multipleGradleJvmArgs`
*  `kotlinJvmArgs`
*  `kotlinProcessesAvailable`
*   `multipleKotlinProcesses`
*   `multipleKotlinJvmArgs`
*    `processesStats`