### PR TITLE
extending default tests with newer gradle versions

### DIFF
--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/DefaultConfigurationSpec.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/DefaultConfigurationSpec.kt
@@ -15,6 +15,8 @@ class DefaultConfigurationSpec : StringSpec({
     "given default config" {
         forAll(
             listOf(
+                "8.6",
+                "8.5",
                 "8.3",
                 "8.2.1",
                 "7.6.2"


### PR DESCRIPTION
Add new Gradle versions in `DefaultConfigurationSpec`