### PR TITLE
Partial support isolated projects

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       image: 'ubuntu-2004:2023.02.1'
     working_directory: ~/repo
     environment:
-      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx8G -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport" -Dorg.gradle.parallel=false -Dorg.gradle.daemon=false
+      GRADLE_OPTS: -Dorg.gradle.jvmargs="-Xmx7G -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport" -Dorg.gradle.parallel=false -Dorg.gradle.daemon=false
       TERM: dumb
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - checkout
       - run:
           name: style
-          command: ./gradlew collectUnitTest
+          command: ./gradlew collectUnitTest --info
   publisherTest:
     machine:
       image: 'ubuntu-2004:2023.02.1'

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/Talaiot.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/Talaiot.kt
@@ -15,6 +15,7 @@ import io.github.cdsap.talaiot.util.ConfigurationPhaseObserver
 import io.github.cdsap.valuesourceprocess.jInfo
 import io.github.cdsap.valuesourceprocess.jStat
 import org.gradle.api.Project
+import org.gradle.api.configuration.BuildFeatures
 import org.gradle.api.provider.Provider
 import org.gradle.build.event.BuildEventsListenerRegistry
 import org.gradle.internal.extensions.core.serviceOf
@@ -47,7 +48,8 @@ class Talaiot<T : TalaiotExtension>(
         val executionReport = ExecutionReport()
         val startTime = System.currentTimeMillis()
         target.gradle.taskGraph.whenReady {
-            val dictionary = it.allTasks.associate { it.path to it.javaClass.toString().replace("class ", "").replace("_Decorated", "") }
+            val isolatedProjects = target.serviceOf<BuildFeatures>().isolatedProjects.active.getOrElse(false)
+            val dictionary = if (isolatedProjects) emptyMap<String, String>() else it.allTasks.associate { it.path to it.javaClass.toString().replace("class ", "").replace("_Decorated", "") }
 
             val parameters = target.gradle.startParameter.taskRequests.flatMap {
                 it.args.flatMap { task ->

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/Talaiot.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/Talaiot.kt
@@ -3,6 +3,7 @@ package io.github.cdsap.talaiot
 import io.github.cdsap.talaiot.configuration.BuildFilterConfiguration
 import io.github.cdsap.talaiot.configuration.MetricsConfiguration
 import io.github.cdsap.talaiot.entities.ExecutionReport
+import io.github.cdsap.talaiot.extensions.gradleVersionCompatibleWithIsolatedProjects
 import io.github.cdsap.talaiot.filter.BuildFilterProcessor
 import io.github.cdsap.talaiot.filter.TaskFilterProcessor
 import io.github.cdsap.talaiot.logger.LogTracker
@@ -19,6 +20,7 @@ import org.gradle.api.configuration.BuildFeatures
 import org.gradle.api.provider.Provider
 import org.gradle.build.event.BuildEventsListenerRegistry
 import org.gradle.internal.extensions.core.serviceOf
+import org.gradle.util.GradleVersion
 
 /**
  * Talaiot main [Plugin].
@@ -48,8 +50,7 @@ class Talaiot<T : TalaiotExtension>(
         val executionReport = ExecutionReport()
         val startTime = System.currentTimeMillis()
         target.gradle.taskGraph.whenReady {
-            val isolatedProjects = target.serviceOf<BuildFeatures>().isolatedProjects.active.getOrElse(false)
-            val dictionary = if (isolatedProjects) emptyMap<String, String>() else it.allTasks.associate { it.path to it.javaClass.toString().replace("class ", "").replace("_Decorated", "") }
+            val dictionary = if (GradleVersion.current().version.gradleVersionCompatibleWithIsolatedProjects() && target.serviceOf<BuildFeatures>().isolatedProjects.active.getOrElse(false)) emptyMap<String, String>() else it.allTasks.associate { it.path to it.javaClass.toString().replace("class ", "").replace("_Decorated", "") }
 
             val parameters = target.gradle.startParameter.taskRequests.flatMap {
                 it.args.flatMap { task ->

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/extensions/String.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/extensions/String.kt
@@ -22,3 +22,25 @@ fun String.toBytes(): String? {
     }
     return null
 }
+
+fun String.gradleVersionCompatibleWithIsolatedProjects(): Boolean {
+    fun parseVersion(version: String): List<Int> {
+        return version.split(Regex("[^\\d]+")).filter { it.isNotEmpty() }.map { it.toInt() }
+    }
+
+    val versionParts = parseVersion(this)
+    val targetVersionParts = parseVersion("8.5")
+    val maxLength = maxOf(versionParts.size, targetVersionParts.size)
+    for (i in 0 until maxLength) {
+        val vPart = versionParts.getOrElse(i) { 0 }
+
+        val tPart = targetVersionParts.getOrElse(i) { 0 }
+        if (vPart > tPart) {
+            return true
+        }
+        if (vPart < tPart) {
+            return false
+        }
+    }
+    return true
+}

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/IsolatedProjectsHit.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/IsolatedProjectsHit.kt
@@ -15,7 +15,9 @@ class IsolatedProjectsHit : StringSpec({
     "given default config" {
         forAll(
             listOf(
-                "8.10"
+                "8.10",
+                "8.5",
+                "7.6.2"
             )
         ) { version: String ->
             val testProjectDir = TemporaryFolder()
@@ -40,13 +42,13 @@ class IsolatedProjectsHit : StringSpec({
 
                 """.trimIndent()
             )
-            val a = GradleRunner.create()
+            GradleRunner.create()
                 .withProjectDir(testProjectDir.getRoot())
                 .withArguments("assemble", "-Dorg.gradle.unsafe.isolated-projects=true")
                 .withPluginClasspath()
                 .withGradleVersion(version)
                 .build()
-            println(a.output)
+
             Thread.sleep(5000)
             val reportFile = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
             val report = Gson().fromJson(reportFile.readText(), ExecutionReport::class.java)
@@ -54,13 +56,12 @@ class IsolatedProjectsHit : StringSpec({
             report.configurationCacheHit shouldBe false
             report.configurationDurationMs shouldNotStartWith "0"
 
-            val b = GradleRunner.create()
+            GradleRunner.create()
                 .withProjectDir(testProjectDir.getRoot())
                 .withArguments("assemble", "-Dorg.gradle.unsafe.isolated-projects=true")
                 .withPluginClasspath()
                 .withGradleVersion(version)
                 .build()
-            println(b.output)
 
             Thread.sleep(5000)
             val reportFileHit = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/IsolatedProjectsHit.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/IsolatedProjectsHit.kt
@@ -1,0 +1,74 @@
+package io.github.cdsap.talaiot
+
+import com.google.gson.Gson
+import io.github.cdsap.talaiot.entities.ExecutionReport
+import io.github.cdsap.talaiot.utils.TemporaryFolder
+import io.kotlintest.forAll
+import io.kotlintest.matchers.string.shouldNotStartWith
+import io.kotlintest.matchers.string.shouldStartWith
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+import org.gradle.testkit.runner.GradleRunner
+import java.io.File
+
+class IsolatedProjectsHit : StringSpec({
+    "given default config" {
+        forAll(
+            listOf(
+                "8.10"
+            )
+        ) { version: String ->
+            val testProjectDir = TemporaryFolder()
+
+            testProjectDir.create()
+            val buildFile = testProjectDir.newFile("build.gradle.kts")
+            buildFile.appendText(
+                """
+                import io.github.cdsap.talaiot.publisher.JsonPublisher
+                plugins {
+                    id ("java")
+                    id ("io.github.cdsap.talaiot")
+                }
+
+                talaiot {
+                    logger = io.github.cdsap.talaiot.logger.LogTracker.Mode.INFO
+                    publishers {
+                         jsonPublisher = true
+                    }
+
+                }
+
+                """.trimIndent()
+            )
+            val a = GradleRunner.create()
+                .withProjectDir(testProjectDir.getRoot())
+                .withArguments("assemble", "-Dorg.gradle.unsafe.isolated-projects=true")
+                .withPluginClasspath()
+                .withGradleVersion(version)
+                .build()
+            println(a.output)
+            Thread.sleep(5000)
+            val reportFile = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
+            val report = Gson().fromJson(reportFile.readText(), ExecutionReport::class.java)
+
+            report.configurationCacheHit shouldBe false
+            report.configurationDurationMs shouldNotStartWith "0"
+
+            val b = GradleRunner.create()
+                .withProjectDir(testProjectDir.getRoot())
+                .withArguments("assemble", "-Dorg.gradle.unsafe.isolated-projects=true")
+                .withPluginClasspath()
+                .withGradleVersion(version)
+                .build()
+            println(b.output)
+
+            Thread.sleep(5000)
+            val reportFileHit = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
+            val reportHit = Gson().fromJson(reportFileHit.readText(), ExecutionReport::class.java)
+
+            testProjectDir.delete()
+            reportHit.configurationCacheHit shouldBe true
+            reportHit.configurationDurationMs shouldStartWith "0"
+        }
+    }
+})

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/IsolatedProjectsHit.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/IsolatedProjectsHit.kt
@@ -37,7 +37,9 @@ class IsolatedProjectsHit : StringSpec({
                     publishers {
                          jsonPublisher = true
                     }
-
+                   metrics {
+                      gitMetrics = false
+                   }
                 }
 
                 """.trimIndent()

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/IsolatedProjectsHit.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/IsolatedProjectsHit.kt
@@ -42,12 +42,14 @@ class IsolatedProjectsHit : StringSpec({
 
                 """.trimIndent()
             )
-            GradleRunner.create()
+            val first = GradleRunner.create()
                 .withProjectDir(testProjectDir.getRoot())
                 .withArguments("assemble", "-Dorg.gradle.unsafe.isolated-projects=true")
                 .withPluginClasspath()
                 .withGradleVersion(version)
                 .build()
+            println(version)
+            println(first.output)
 
             Thread.sleep(5000)
             val reportFile = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
@@ -56,12 +58,14 @@ class IsolatedProjectsHit : StringSpec({
             report.configurationCacheHit shouldBe false
             report.configurationDurationMs shouldNotStartWith "0"
 
-            GradleRunner.create()
+            val second = GradleRunner.create()
                 .withProjectDir(testProjectDir.getRoot())
                 .withArguments("assemble", "-Dorg.gradle.unsafe.isolated-projects=true")
                 .withPluginClasspath()
                 .withGradleVersion(version)
                 .build()
+            println(version)
+            println(second.output)
 
             Thread.sleep(5000)
             val reportFileHit = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")


### PR DESCRIPTION
First part to cover #406, with this PR plugin is not failing with isolated projects affecting the `TaskAbbreviationMatcher` and the dictionary provided to map tasks and types.