### PR TITLE
Adding support for ValueSources in custom metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,17 +195,34 @@ talaiot {
         customTaskMetrics(
             "customProperty" to $value
         )
-
-        // custom metric with ValueSource providers
-        customBuildMetricsWithProviders(
-            "metric1" to providers.of(MyValueSource::class) {}
-        )
-
     }
 }
 ```
 
 Read more about it in the [Metrics wiki page](https://github.com/cdsap/Talaiot/wiki/Metrics).
+
+#### Experimental Provider Metrics
+Since version 2.1.0, Talaiot includes an experimental mechanism to define metrics using a provider-based system compatible with Configuration Cache.
+This approach allows you to lazily evaluate metric values, ensuring that they are resolved only when needed during the build lifecycle.
+Two entry points are available for executing these providers:
+* Initialization phase – executed at the start of the execution phase.
+* Finalization phase – executed once the build has finished.
+
+These APIs (`initialProviderMetrics` and `finalProviderMetrics`) are marked as experimental and may change in future versions.
+You can suppress the compiler warning by explicitly opting in with `@OptIn(ExperimentalMetricsApi::class)`.
+
+Example:
+```
+metrics {
+    initialProviderMetrics(
+        "init_memory_metric" to providers.of(GetMemory::class) {}
+    )
+    finalProviderMetrics(
+        "end_memory_metric" to providers.of(GetMemory::class) {}
+    )
+}
+
+```
 
 ### Filters
 For every measurement done, Talaiot can filter the tasks tracked to be published.

--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ talaiot {
         customTaskMetrics(
             "customProperty" to $value
         )
+
+        // custom metric with ValueSource providers
+        customBuildMetricsWithProviders(
+            "metric1" to providers.of(MyValueSource::class) {}
+        )
+
     }
 }
 ```

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/Talaiot.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/Talaiot.kt
@@ -96,6 +96,8 @@ class Talaiot<T : TalaiotExtension>(
                     spec.parameters.processGitBranchMetric.set(extension.metrics.gitMetrics)
                     spec.parameters.processBuildId.set(extension.metrics.generateBuildId)
                     spec.parameters.buildId = buildId
+                    spec.parameters.buildProviderMetrics.set(extension.metrics.buildProviderMetrics)
+                    spec.parameters.taskProviderMetrics.set(extension.metrics.taskProviderMetrics)
                 }
             target.serviceOf<BuildEventsListenerRegistry>().onTaskCompletion(serviceProvider)
         }

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/Talaiot.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/Talaiot.kt
@@ -96,8 +96,8 @@ class Talaiot<T : TalaiotExtension>(
                     spec.parameters.processGitBranchMetric.set(extension.metrics.gitMetrics)
                     spec.parameters.processBuildId.set(extension.metrics.generateBuildId)
                     spec.parameters.buildId = buildId
-                    spec.parameters.buildProviderMetrics.set(extension.metrics.buildProviderMetrics)
-                    spec.parameters.taskProviderMetrics.set(extension.metrics.taskProviderMetrics)
+                    spec.parameters.endProviderMetrics.set(extension.metrics.endProviderMetrics)
+                    spec.parameters.initProviderMetrics.set(extension.metrics.initProviderMetrics)
                 }
             target.serviceOf<BuildEventsListenerRegistry>().onTaskCompletion(serviceProvider)
         }

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/TalaiotBuildService.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/TalaiotBuildService.kt
@@ -55,17 +55,23 @@ abstract class TalaiotBuildService :
         var gitBranchMetric: Provider<String>
         var buildId: Provider<String>
         val processBuildId: Property<Boolean>
-        val buildProviderMetrics: MapProperty<String, Provider<out Any>>
-        val taskProviderMetrics: MapProperty<String, Provider<out Any>>
+        val initProviderMetrics: MapProperty<String, Provider<out Any>>
+        val endProviderMetrics: MapProperty<String, Provider<out Any>>
     }
 
     private val taskLengthList = mutableListOf<TaskLength>()
 
     private val startParameters by lazy { parameters.startParameters.get() }
     private val dictionary by lazy { parameters.dictionary.get() }
+    private val initProviderMetrics = mutableMapOf<String, Any>()
 
     init {
         start = System.currentTimeMillis()
+        initProviderMetrics.putAll(
+            parameters.initProviderMetrics.get().map {
+                it.key to it.value.get()
+            }
+        )
     }
 
     override fun close() {
@@ -114,8 +120,8 @@ abstract class TalaiotBuildService :
             gitBranchMetric = gitBranchMetric,
             processBuildId = parameters.processBuildId.get(),
             buildId = buildId,
-            taskMetricsWithProviders = parameters.taskProviderMetrics.get().mapValues { it.value.get() },
-            buildMetricsWithProviders = parameters.buildProviderMetrics.get().mapValues { it.value.get() }
+            initMetricsWithProviders = initProviderMetrics,
+            endMetricsWithProviders = parameters.endProviderMetrics.get().mapValues { it.value.get() }
         )
     }
 

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/TalaiotBuildService.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/TalaiotBuildService.kt
@@ -55,6 +55,8 @@ abstract class TalaiotBuildService :
         var gitBranchMetric: Provider<String>
         var buildId: Provider<String>
         val processBuildId: Property<Boolean>
+        val buildProviderMetrics: MapProperty<String, Provider<out Any>>
+        val taskProviderMetrics: MapProperty<String, Provider<out Any>>
     }
 
     private val taskLengthList = mutableListOf<TaskLength>()
@@ -111,7 +113,9 @@ abstract class TalaiotBuildService :
             processGitBranchMetric = processGitBranchMetric,
             gitBranchMetric = gitBranchMetric,
             processBuildId = parameters.processBuildId.get(),
-            buildId = buildId
+            buildId = buildId,
+            taskMetricsWithProviders = parameters.taskProviderMetrics.get().mapValues { it.value.get() },
+            buildMetricsWithProviders = parameters.buildProviderMetrics.get().mapValues { it.value.get() }
         )
     }
 

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/configuration/MetricsConfiguration.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/configuration/MetricsConfiguration.kt
@@ -27,6 +27,7 @@ import io.github.cdsap.talaiot.metrics.SimpleMetric
 import io.github.cdsap.talaiot.metrics.UserMetric
 import io.github.cdsap.talaiot.metrics.base.Metric
 import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 
 /**
  * Configuration for the Metrics extensions
@@ -115,6 +116,8 @@ class MetricsConfiguration {
     var processMetrics = true
 
     private var metrics: MutableSet<Metric<*, *>> = mutableSetOf()
+    var buildProviderMetrics = mapOf<String, Provider<out Any>>()
+    var taskProviderMetrics = mapOf<String, Provider<out Any>>()
 
     private fun addDefaultMetrics() {
         with(metrics) {
@@ -196,6 +199,14 @@ class MetricsConfiguration {
      */
     fun customBuildMetrics(buildMetric: Pair<String, Any>) {
         metrics.add(createSimpleBuildMetric(buildMetric))
+    }
+
+    fun customBuildMetricsWithProviders(vararg metricsWithProvider: Pair<String, Provider<out Any>>) {
+        buildProviderMetrics = metricsWithProvider.associate { it.first to it.second }.toMutableMap()
+    }
+
+    fun customTaskMetricsWithProviders(vararg metricsWithProvider: Pair<String, Provider<out Any>>) {
+        taskProviderMetrics = metricsWithProvider.associate { it.first to it.second }.toMutableMap()
     }
 
     /**

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/configuration/MetricsConfiguration.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/configuration/MetricsConfiguration.kt
@@ -2,6 +2,7 @@ package io.github.cdsap.talaiot.configuration
 
 import io.github.cdsap.talaiot.entities.ExecutionReport
 import io.github.cdsap.talaiot.metrics.DefaultCharsetMetric
+import io.github.cdsap.talaiot.metrics.ExperimentalMetricsApi
 import io.github.cdsap.talaiot.metrics.GitUserMetric
 import io.github.cdsap.talaiot.metrics.GradleMaxWorkersMetric
 import io.github.cdsap.talaiot.metrics.GradleRequestedTasksMetric
@@ -116,8 +117,8 @@ class MetricsConfiguration {
     var processMetrics = true
 
     private var metrics: MutableSet<Metric<*, *>> = mutableSetOf()
-    var buildProviderMetrics = mapOf<String, Provider<out Any>>()
-    var taskProviderMetrics = mapOf<String, Provider<out Any>>()
+    var initProviderMetrics = mapOf<String, Provider<out Any>>()
+    var endProviderMetrics = mapOf<String, Provider<out Any>>()
 
     private fun addDefaultMetrics() {
         with(metrics) {
@@ -201,12 +202,14 @@ class MetricsConfiguration {
         metrics.add(createSimpleBuildMetric(buildMetric))
     }
 
-    fun customBuildMetricsWithProviders(vararg metricsWithProvider: Pair<String, Provider<out Any>>) {
-        buildProviderMetrics = metricsWithProvider.associate { it.first to it.second }.toMutableMap()
+    @ExperimentalMetricsApi
+    fun initialProviderMetrics(vararg metricsWithProvider: Pair<String, Provider<out Any>>) {
+        initProviderMetrics = metricsWithProvider.associate { it.first to it.second }.toMutableMap()
     }
 
-    fun customTaskMetricsWithProviders(vararg metricsWithProvider: Pair<String, Provider<out Any>>) {
-        taskProviderMetrics = metricsWithProvider.associate { it.first to it.second }.toMutableMap()
+    @ExperimentalMetricsApi
+    fun finalProviderMetrics(vararg metricsWithProvider: Pair<String, Provider<out Any>>) {
+        endProviderMetrics = metricsWithProvider.associate { it.first to it.second }.toMutableMap()
     }
 
     /**

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/ExperimentalMetricsApi.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/ExperimentalMetricsApi.kt
@@ -8,4 +8,3 @@ package io.github.cdsap.talaiot.metrics
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
 annotation class ExperimentalMetricsApi
-

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/ExperimentalMetricsApi.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/metrics/ExperimentalMetricsApi.kt
@@ -1,0 +1,11 @@
+package io.github.cdsap.talaiot.metrics
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "Initial and Final Metrics with Providers are experimental. " +
+        "You can silence this message using @OptIn(ExperimentalMetricsApi::class)."
+)
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.PROPERTY, AnnotationTarget.CLASS)
+annotation class ExperimentalMetricsApi
+

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisher.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisher.kt
@@ -25,7 +25,7 @@ interface TalaiotPublisher : java.io.Serializable {
         gitBranchMetric: String,
         processBuildId: Boolean,
         buildId: String,
-        taskMetricsWithProviders: Map<String, Any>,
-        buildMetricsWithProviders: Map<String, Any>
+        initMetricsWithProviders: Map<String, Any>,
+        endMetricsWithProviders: Map<String, Any>
     )
 }

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisher.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisher.kt
@@ -24,6 +24,8 @@ interface TalaiotPublisher : java.io.Serializable {
         processGitBranchMetric: Boolean,
         gitBranchMetric: String,
         processBuildId: Boolean,
-        buildId: String
+        buildId: String,
+        taskMetricsWithProviders: Map<String, Any>,
+        buildMetricsWithProviders: Map<String, Any>
     )
 }

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisherImpl.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisherImpl.kt
@@ -43,8 +43,8 @@ class TalaiotPublisherImpl(
         gitBranchMetric: String,
         processBuildId: Boolean,
         buildId: String,
-        taskMetricsWithProviders: Map<String, Any>,
-        buildMetricsWithProviders: Map<String, Any>
+        initMetricsWithProviders: Map<String, Any>,
+        endMetricsWithProviders: Map<String, Any>
     ) {
         executionReport.tasks = taskLengthList.filter { taskFilterProcessor.taskLengthFilter(it) }
         executionReport.unfilteredTasks = taskLengthList
@@ -55,8 +55,8 @@ class TalaiotPublisherImpl(
         executionReport.durationMs = (duration + configuration).toString()
         executionReport.configurationDurationMs = configuration.toString()
         executionReport.configurationCacheHit = configurationCacheHit
-        executionReport.customProperties.buildProperties.putAll(buildMetricsWithProviders)
-        executionReport.customProperties.taskProperties.putAll(taskMetricsWithProviders)
+        executionReport.customProperties.buildProperties.putAll(initMetricsWithProviders)
+        executionReport.customProperties.buildProperties.putAll(endMetricsWithProviders)
 
         if (buildFilterProcessor.shouldPublishBuild(executionReport)) {
             if (processProcessMetrics) {

--- a/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisherImpl.kt
+++ b/library/core/talaiot/src/main/kotlin/io/github/cdsap/talaiot/publisher/TalaiotPublisherImpl.kt
@@ -42,7 +42,9 @@ class TalaiotPublisherImpl(
         processGitBranchMetric: Boolean,
         gitBranchMetric: String,
         processBuildId: Boolean,
-        buildId: String
+        buildId: String,
+        taskMetricsWithProviders: Map<String, Any>,
+        buildMetricsWithProviders: Map<String, Any>
     ) {
         executionReport.tasks = taskLengthList.filter { taskFilterProcessor.taskLengthFilter(it) }
         executionReport.unfilteredTasks = taskLengthList
@@ -53,6 +55,8 @@ class TalaiotPublisherImpl(
         executionReport.durationMs = (duration + configuration).toString()
         executionReport.configurationDurationMs = configuration.toString()
         executionReport.configurationCacheHit = configurationCacheHit
+        executionReport.customProperties.buildProperties.putAll(buildMetricsWithProviders)
+        executionReport.customProperties.taskProperties.putAll(taskMetricsWithProviders)
 
         if (buildFilterProcessor.shouldPublishBuild(executionReport)) {
             if (processProcessMetrics) {

--- a/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
+++ b/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
@@ -236,7 +236,7 @@ class MetricsConfigurationTest : BehaviorSpec({
             }
         }
         `when`("custom build metrics with providers used") {
-            val expectedBuildProperties = mutableMapOf<String, Provider<out Any>>(
+            val expectedBuildProperties =(
                 "metricA" to target.providers.provider { "valueA" }
             )
             val metricsConfiguration = MetricsConfiguration().apply {

--- a/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
+++ b/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
@@ -246,7 +246,8 @@ class MetricsConfigurationTest : BehaviorSpec({
                 environmentMetrics = false
                 processMetrics = false
 
-                customBuildMetricsWithProviders(expectedBuildProperties)
+                initialProviderMetrics(expectedBuildProperties)
+                finalProviderMetrics(expectedBuildProperties)
             }
             val metrics = metricsConfiguration.build(target)
             then("metrics are not processed because are evaluated later") {

--- a/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
+++ b/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
@@ -8,6 +8,7 @@ import io.github.cdsap.talaiot.mock.AdbVersionMetric
 import io.github.cdsap.talaiot.mock.KotlinVersionMetric
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.BehaviorSpec
+import org.gradle.api.provider.Provider
 import org.gradle.testfixtures.ProjectBuilder
 
 class MetricsConfigurationTest : BehaviorSpec({
@@ -232,6 +233,25 @@ class MetricsConfigurationTest : BehaviorSpec({
                         expectedTaskProperties
                     )
                 )
+            }
+        }
+        `when`("custom build metrics with providers used") {
+            val expectedBuildProperties = mutableMapOf<String, Provider<out Any>>(
+                "metricA" to target.providers.provider { "valueA" }
+            )
+            val metricsConfiguration = MetricsConfiguration().apply {
+                defaultMetrics = false
+                gitMetrics = false
+                performanceMetrics = false
+                gradleSwitchesMetrics = false
+                environmentMetrics = false
+                processMetrics = false
+
+                customBuildMetricsWithProviders(expectedBuildProperties)
+            }
+            val metrics = metricsConfiguration.build(target)
+            then("metrics are not processed because are evaluated later") {
+                metrics.count().shouldBe(0)
             }
         }
     }

--- a/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
+++ b/library/core/talaiot/src/test/kotlin/io/github/cdsap/talaiot/metrics/MetricsConfigurationTest.kt
@@ -8,7 +8,6 @@ import io.github.cdsap.talaiot.mock.AdbVersionMetric
 import io.github.cdsap.talaiot.mock.KotlinVersionMetric
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.BehaviorSpec
-import org.gradle.api.provider.Provider
 import org.gradle.testfixtures.ProjectBuilder
 
 class MetricsConfigurationTest : BehaviorSpec({
@@ -236,9 +235,9 @@ class MetricsConfigurationTest : BehaviorSpec({
             }
         }
         `when`("custom build metrics with providers used") {
-            val expectedBuildProperties =(
+            val expectedBuildProperties = (
                 "metricA" to target.providers.provider { "valueA" }
-            )
+                )
             val metricsConfiguration = MetricsConfiguration().apply {
                 defaultMetrics = false
                 gitMetrics = false

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/MetricWithProviderTest.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/MetricWithProviderTest.kt
@@ -1,0 +1,113 @@
+package io.github.cdsap.talaiot
+
+import com.google.gson.Gson
+import io.github.cdsap.talaiot.entities.ExecutionReport
+import io.github.cdsap.talaiot.utils.TemporaryFolder
+import io.kotlintest.forAll
+import io.kotlintest.matchers.collections.shouldNotBeOneOf
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.StringSpec
+import org.gradle.testkit.runner.GradleRunner
+import java.io.File
+
+class MetricWithProviderTest : StringSpec({
+    "given a build with process metrics enabled" {
+        forAll(
+            listOf(
+                "9.2.0"
+            )
+        ) { version: String ->
+            val testProjectDir = TemporaryFolder()
+
+            testProjectDir.create()
+            val buildFile = testProjectDir.newFile("build.gradle.kts")
+            buildFile.appendText(
+                """
+                import io.github.cdsap.talaiot.publisher.JsonPublisher
+                plugins {
+                    id ("java")
+                    id ("io.github.cdsap.talaiot")
+                }
+
+                talaiot {
+                    logger = io.github.cdsap.talaiot.logger.LogTracker.Mode.INFO
+                    publishers {
+                         jsonPublisher = true
+                    }
+                    metrics {
+                      customBuildMetricsWithProviders(
+                         "metric1" to  providers.of(A::class) {},
+                         "metric2" to  providers.provider { System.nanoTime().toString() }
+                      )
+                    }
+                }
+
+                abstract class A : ValueSource<String, ValueSourceParameters.None> {
+                    override fun obtain(): String? {
+                        return System.nanoTime().toString()
+                    }
+                }
+
+                """.trimIndent()
+            )
+            val b1 = GradleRunner.create()
+                .withProjectDir(testProjectDir.getRoot())
+                .withArguments("assemble", "--configuration-cache")
+                .withPluginClasspath()
+                .withGradleVersion(version)
+                .build()
+            Thread.sleep(5000)
+            val reportFile = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
+            val report = Gson().fromJson(reportFile.readText(), ExecutionReport::class.java)
+
+            val b2 = GradleRunner.create()
+                .withProjectDir(testProjectDir.getRoot())
+                .withArguments("assemble", "--configuration-cache")
+                .withPluginClasspath()
+                .withGradleVersion(version)
+                .build()
+            Thread.sleep(5000)
+            val reportFile2 = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
+            val report2 = Gson().fromJson(reportFile2.readText(), ExecutionReport::class.java)
+
+            val b3 = GradleRunner.create()
+                .withProjectDir(testProjectDir.getRoot())
+                .withArguments("assemble", "--configuration-cache")
+                .withPluginClasspath()
+                .withGradleVersion(version)
+                .build()
+            val reportFile3 = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
+            val report3 = Gson().fromJson(reportFile3.readText(), ExecutionReport::class.java)
+
+            val b4 = GradleRunner.create()
+                .withProjectDir(testProjectDir.getRoot())
+                .withArguments("assemble", "--configuration-cache")
+                .withPluginClasspath()
+                .withGradleVersion(version)
+                .build()
+            val reportFile4 = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
+            val report4 = Gson().fromJson(reportFile4.readText(), ExecutionReport::class.java)
+
+            testProjectDir.delete()
+
+            val metric1_build1 = report.customProperties.buildProperties["metric1"]
+
+            val metric1_build2 = report2.customProperties.buildProperties["metric1"]
+
+            val metric1_build3 = report3.customProperties.buildProperties["metric1"]
+            val metric2_build3 = report3.customProperties.buildProperties["metric2"]
+
+            val metric1_build4 = report4.customProperties.buildProperties["metric1"]
+            val metric2_build4 = report4.customProperties.buildProperties["metric2"]
+
+            metric1_build4 shouldNotBeOneOf listOf(metric1_build1, metric1_build2, metric1_build3)
+            // if we want to keep a evaluation of the provider every time we need to use ValueSource
+            // if we are using providers like in this test for metric2:
+            // providers.provider { System.nanoTime().toString() }
+            // the expectation os that the value is not going to be evaluated.
+            // that's why the previous assertion is used for value sources and the following one
+            // only represents the providers.
+            metric2_build4 shouldBe metric2_build3
+        }
+    }
+})

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/MetricWithProviderTest.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/MetricWithProviderTest.kt
@@ -5,13 +5,14 @@ import io.github.cdsap.talaiot.entities.ExecutionReport
 import io.github.cdsap.talaiot.utils.TemporaryFolder
 import io.kotlintest.forAll
 import io.kotlintest.matchers.collections.shouldNotBeOneOf
+import io.kotlintest.matchers.numerics.shouldBeGreaterThan
 import io.kotlintest.shouldBe
 import io.kotlintest.specs.StringSpec
 import org.gradle.testkit.runner.GradleRunner
 import java.io.File
 
 class MetricWithProviderTest : StringSpec({
-    "given a build with process metrics enabled" {
+    "given a build with provider metrics, ValueSources are corrected processed when configuration cache hits and regular provider not" {
         forAll(
             listOf(
                 "9.2.0"
@@ -35,7 +36,7 @@ class MetricWithProviderTest : StringSpec({
                          jsonPublisher = true
                     }
                     metrics {
-                      customBuildMetricsWithProviders(
+                      initialProviderMetrics(
                          "metric1" to  providers.of(A::class) {},
                          "metric2" to  providers.provider { System.nanoTime().toString() }
                       )
@@ -48,9 +49,11 @@ class MetricWithProviderTest : StringSpec({
                     }
                 }
 
+
+
                 """.trimIndent()
             )
-            val b1 = GradleRunner.create()
+            GradleRunner.create()
                 .withProjectDir(testProjectDir.getRoot())
                 .withArguments("assemble", "--configuration-cache")
                 .withPluginClasspath()
@@ -60,7 +63,7 @@ class MetricWithProviderTest : StringSpec({
             val reportFile = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
             val report = Gson().fromJson(reportFile.readText(), ExecutionReport::class.java)
 
-            val b2 = GradleRunner.create()
+            GradleRunner.create()
                 .withProjectDir(testProjectDir.getRoot())
                 .withArguments("assemble", "--configuration-cache")
                 .withPluginClasspath()
@@ -70,7 +73,7 @@ class MetricWithProviderTest : StringSpec({
             val reportFile2 = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
             val report2 = Gson().fromJson(reportFile2.readText(), ExecutionReport::class.java)
 
-            val b3 = GradleRunner.create()
+            GradleRunner.create()
                 .withProjectDir(testProjectDir.getRoot())
                 .withArguments("assemble", "--configuration-cache")
                 .withPluginClasspath()
@@ -79,7 +82,7 @@ class MetricWithProviderTest : StringSpec({
             val reportFile3 = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
             val report3 = Gson().fromJson(reportFile3.readText(), ExecutionReport::class.java)
 
-            val b4 = GradleRunner.create()
+            GradleRunner.create()
                 .withProjectDir(testProjectDir.getRoot())
                 .withArguments("assemble", "--configuration-cache")
                 .withPluginClasspath()
@@ -90,24 +93,98 @@ class MetricWithProviderTest : StringSpec({
 
             testProjectDir.delete()
 
-            val metric1_build1 = report.customProperties.buildProperties["metric1"]
+            val metric1Build1 = report.customProperties.buildProperties["metric1"]
+            val metric1Build2 = report2.customProperties.buildProperties["metric1"]
+            val metric1Build3 = report3.customProperties.buildProperties["metric1"]
+            val metric2Build3 = report3.customProperties.buildProperties["metric2"]
+            val metric1Build4 = report4.customProperties.buildProperties["metric1"]
+            val metric2Build4 = report4.customProperties.buildProperties["metric2"]
 
-            val metric1_build2 = report2.customProperties.buildProperties["metric1"]
-
-            val metric1_build3 = report3.customProperties.buildProperties["metric1"]
-            val metric2_build3 = report3.customProperties.buildProperties["metric2"]
-
-            val metric1_build4 = report4.customProperties.buildProperties["metric1"]
-            val metric2_build4 = report4.customProperties.buildProperties["metric2"]
-
-            metric1_build4 shouldNotBeOneOf listOf(metric1_build1, metric1_build2, metric1_build3)
+            metric1Build4 shouldNotBeOneOf listOf(metric1Build1, metric1Build2, metric1Build3)
             // if we want to keep a evaluation of the provider every time we need to use ValueSource
             // if we are using providers like in this test for metric2:
             // providers.provider { System.nanoTime().toString() }
             // the expectation os that the value is not going to be evaluated.
             // that's why the previous assertion is used for value sources and the following one
             // only represents the providers.
-            metric2_build4 shouldBe metric2_build3
+            metric2Build4 shouldBe metric2Build3
+        }
+    }
+
+    "given a build with init and final provider metrics, metrics are correctly assigned" {
+        forAll(
+            listOf(
+                "9.2.0"
+            )
+        ) { version: String ->
+            val testProjectDir = TemporaryFolder()
+
+            testProjectDir.create()
+            val buildFile = testProjectDir.newFile("build.gradle.kts")
+            buildFile.appendText(
+                """
+                import io.github.cdsap.talaiot.publisher.JsonPublisher
+                plugins {
+                    id ("java")
+                    id ("io.github.cdsap.talaiot")
+                }
+
+                tasks.register<DefaultTask>("commonTask") {
+                    doLast {
+                     println("1 "+System.nanoTime())
+                     println("2"+System.nanoTime())
+                    }
+                }
+
+                talaiot {
+                    logger = io.github.cdsap.talaiot.logger.LogTracker.Mode.INFO
+                    publishers {
+                         jsonPublisher = true
+                    }
+                    metrics {
+                      initialProviderMetrics(
+                         "init_metric" to  providers.of(A::class) {}
+                      )
+                      finalProviderMetrics(
+                         "end_metric" to  providers.of(A::class) {}
+
+                      )
+                    }
+                }
+
+                abstract class A : ValueSource<Long, ValueSourceParameters.None> {
+                    override fun obtain(): Long? {
+                       Thread.sleep(10000)
+                        return System.nanoTime()
+                    }
+                }
+                """.trimIndent()
+            )
+            GradleRunner.create()
+                .withProjectDir(testProjectDir.getRoot())
+                .withArguments("commonTask", "--configuration-cache")
+                .withPluginClasspath()
+                .withGradleVersion(version)
+                .build()
+            Thread.sleep(5000)
+            val reportFile = File(testProjectDir.getRoot(), "build/reports/talaiot/json/data.json")
+            val report = Gson().fromJson(reportFile.readText(), ExecutionReport::class.java)
+            val raw = report.customProperties.buildProperties["init_metric"]
+            val raw2 = report.customProperties.buildProperties["end_metric"]
+            val initMetric: Long? = lng(raw)
+            val endMetric: Long? = lng(raw2)
+            val diff = endMetric!! - initMetric!!
+            // we have forced a thread sleep of 10 seconds in the ValueSource obtain method
+            // so the difference between the first and second metric should be at least 10 seconds in nanoseconds
+            diff shouldBeGreaterThan 10000000000L
         }
     }
 })
+
+private fun lng(value: Any?): Long? = when (value) {
+    is Long -> value
+    is Int -> value.toLong()
+    is Double -> value.toLong()
+    is Number -> value.toLong()
+    else -> null // or throw
+}

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/MetricWithProviderTest.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/MetricWithProviderTest.kt
@@ -12,7 +12,7 @@ import org.gradle.testkit.runner.GradleRunner
 import java.io.File
 
 class MetricWithProviderTest : StringSpec({
-    "given a build with provider metrics, ValueSources are corrected processed when configuration cache hits and regular provider not" {
+    "given a build with provider metrics, ValueSources are correctly processed when configuration cache hits and regular provider not" {
         forAll(
             listOf(
                 "9.2.0"

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/MetricWithProviderTest.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/MetricWithProviderTest.kt
@@ -104,7 +104,7 @@ class MetricWithProviderTest : StringSpec({
             // if we want to keep a evaluation of the provider every time we need to use ValueSource
             // if we are using providers like in this test for metric2:
             // providers.provider { System.nanoTime().toString() }
-            // the expectation os that the value is not going to be evaluated.
+            // the expectation is that the value is not going to be evaluated.
             // that's why the previous assertion is used for value sources and the following one
             // only represents the providers.
             metric2Build4 shouldBe metric2Build3

--- a/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/TalaiotPublisherImplTest.kt
+++ b/library/plugins/talaiot-standard/src/test/kotlin/io/github/cdsap/talaiot/TalaiotPublisherImplTest.kt
@@ -400,7 +400,9 @@ class TalaiotPublisherImplTest : BehaviorSpec({
                 false,
                 "",
                 false,
-                ""
+                "",
+                emptyMap(),
+                emptyMap()
             )
             then("should publish cache information for each task") {
                 val reportCaptor = argumentCaptor<ExecutionReport>()
@@ -493,7 +495,9 @@ private fun publish(
         false,
         "",
         false,
-        ""
+        "",
+        emptyMap(),
+        emptyMap()
     )
 }
 


### PR DESCRIPTION

This PR introduces experimental support for provider-based metrics in Talaiot, enabling lazy evaluation of metric values that are compatible with Gradle's Configuration Cache. The implementation adds two new APIs (`initialProviderMetrics` and `finalProviderMetrics`) for capturing metrics at different phases of the build lifecycle.

**Key Changes:**
- Added experimental provider-based metrics APIs with `@ExperimentalMetricsApi` annotation
- Implemented initialization and finalization phase metric collection using Gradle providers
- Added comprehensive test coverage for provider metrics with Configuration Cache scenarios
