### PR TITLE
Enable Renovate automerge for Maven dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,18 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "config:base"
+    ],
+    "packageRules": [
+        {
+            "matchDatasources": ["maven"],
+            "registryUrls": [
+                "https://dl.google.com/dl/android/maven2/",
+                "https://plugins.gradle.org/m2/",
+                "https://repo1.maven.org/maven2/"
+            ],
+            "automerge": true,
+            "automergeType": "pr",
+            "automergeStrategy": "merge-commit"
+        }
     ]
 }


### PR DESCRIPTION
## Summary
- Add Maven `packageRules` with automerge (`pr` / `merge-commit`) for Google Maven, Gradle Plugin Portal, and Maven Central
- Aligns Talaiot Renovate config with ProjectGenerator / GEApiData

## Test plan
- [ ] Renovate Dashboard / next run picks up the new `packageRules`
- [ ] A green Maven dependency PR is automerged (or eligible for automerge)
- [ ] Non-Maven updates are unchanged


Made with [Cursor](https://cursor.com)